### PR TITLE
Update Golang version from 1.23 to 1.24

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Build all entry points
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 - **プラットフォーム**: Cloud Run (コンテナベース)
 - **フレームワーク**: Gin (Go製高速Webフレームワーク)
 - **データベース**: DatastoreモードFirestore (既存データと互換性を保持)
-- **言語**: Go 1.23+
+- **言語**: Go 1.24+
 - **認証**: Twitter OAuth + Firebase Authentication
 
 ## 🚀 クイックスタート
 
 ### 前提条件
 
-- Go 1.23以上
+- Go 1.24以上
 - GitHub CLI (`gh`) - デプロイスクリプト用
 
 ### ローカル開発
@@ -95,7 +95,7 @@ go build -v ./...
 ## 🚀 CI/CD
 
 GitHub Actionsによる自動CI/CDを設定済み：
-- **PR検証**: Go 1.23での自動テスト・ビルド
+- **PR検証**: Go 1.24での自動テスト・ビルド
 - **自動デプロイ**: DEV環境（mainブランチ）、本番環境（手動実行）
 
 


### PR DESCRIPTION
## Summary
- Update Docker base image from `golang:1.23-alpine` to `golang:1.24-alpine`
- Update GitHub Actions workflows to use Go 1.24 instead of 1.23
- Update documentation (README.md) to reflect Go 1.24 requirement

## Test plan
- [x] Verify Docker build succeeds with Go 1.24
- [x] Ensure GitHub Actions CI passes with Go 1.24
- [x] Confirm all version references are updated consistently

🤖 Generated with [Claude Code](https://claude.ai/code)