### PR TITLE
Fix GitHub Actions deployment error by migrating to Artifact Registry

### DIFF
--- a/.github/workflows/deploy-common.yml
+++ b/.github/workflows/deploy-common.yml
@@ -47,20 +47,20 @@ jobs:
       with:
         project_id: ${{ inputs.project_id }}
 
-    - name: Configure Docker for GCR
-      run: gcloud auth configure-docker
+    - name: Configure Docker for Artifact Registry
+      run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev
 
     - name: Build and push Docker image
       run: |
-        docker build -t gcr.io/${{ inputs.project_id }}/${{ env.SERVICE_NAME }}:${{ github.sha }} .
-        docker push gcr.io/${{ inputs.project_id }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
+        docker build -t asia-northeast1-docker.pkg.dev/${{ inputs.project_id }}/kyouen-repo/${{ env.SERVICE_NAME }}:${{ github.sha }} .
+        docker push asia-northeast1-docker.pkg.dev/${{ inputs.project_id }}/kyouen-repo/${{ env.SERVICE_NAME }}:${{ github.sha }}
 
     - name: Deploy to Cloud Run
       run: |
         SERVICE_NAME_WITH_ENV="${{ env.SERVICE_NAME }}-${{ inputs.environment }}"
         
         gcloud run deploy $SERVICE_NAME_WITH_ENV \
-          --image gcr.io/${{ inputs.project_id }}/${{ env.SERVICE_NAME }}:${{ github.sha }} \
+          --image asia-northeast1-docker.pkg.dev/${{ inputs.project_id }}/kyouen-repo/${{ env.SERVICE_NAME }}:${{ github.sha }} \
           --region ${{ env.REGION }} \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
## Summary
- Migrate from deprecated GCR to Artifact Registry for container image storage
- Fix GitHub Actions deployment failures caused by GCR connection issues
- Update Docker authentication configuration for better reliability

## Changes
- Replace `gcr.io` with `asia-northeast1-docker.pkg.dev` image URLs
- Update Docker authentication command to use Artifact Registry
- Maintain same functionality with improved reliability

## Prerequisites
Before merging, the following Artifact Registry repositories need to be created:

**DEV Environment:**
```bash
gcloud artifacts repositories create kyouen-repo \
  --repository-format=docker \
  --location=asia-northeast1 \
  --description="Docker repository for kyouen-server" \
  --project=api-project-732262258565
```

**Production Environment:**
```bash
gcloud artifacts repositories create kyouen-repo \
  --repository-format=docker \
  --location=asia-northeast1 \
  --description="Docker repository for kyouen-server" \
  --project=my-android-server
```

## Test Plan
- [ ] Create Artifact Registry repositories in both environments
- [ ] Verify GitHub Actions deployment workflow completes successfully
- [ ] Confirm Cloud Run service deployment works correctly
- [ ] Test application health endpoint after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)