### PR TITLE
Add Swagger UI endpoint for API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ go run cmd/server/main.go
 GET /health
 ```
 
+### API ドキュメント
+```
+GET /static/swagger-ui.html   # Swagger UI
+GET /docs/specs/index.yaml    # OpenAPI仕様
+```
+
 ### 統計情報
 ```
 GET /v2/statics

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -90,6 +90,10 @@ func setupRouter(app *App) *gin.Engine {
 		})
 	})
 
+	// Swagger UI endpoints
+	router.StaticFile("/docs/specs/index.yaml", "./docs/specs/index.yaml")
+	router.StaticFile("/static/swagger-ui.html", "./static-files/swagger-ui.html")
+
 	// Initialize handlers
 	stageHandler := stage.NewHandler(app.DatastoreService, app.FirebaseService)
 	staticsHandler := statics.NewHandler(app.DatastoreService)

--- a/static-files/swagger-ui.html
+++ b/static-files/swagger-ui.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Kyouen API Documentation</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui.css" />
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-bundle.js"></script>
+    <script>
+        SwaggerUIBundle({
+            url: '/docs/specs/index.yaml',
+            dom_id: '#swagger-ui',
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIBundle.presets.standalone
+            ]
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/static/swagger-ui.html` endpoint serving Swagger UI interface
- Add `/docs/specs/index.yaml` endpoint for OpenAPI specification access
- Create `static-files/` directory for organizing static content

## Test plan
- [x] Verify Swagger UI loads correctly at `/static/swagger-ui.html`
- [x] Verify OpenAPI spec is accessible at `/docs/specs/index.yaml`
- [x] Update README.md with new API documentation endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)