### PR TITLE
Fix Swagger UI 404 error by including static files in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR /root/
 # ビルドしたバイナリをコピー
 COPY --from=builder /app/server .
 
+# 静的ファイルをコピー
+COPY --from=builder /app/static-files ./static-files
+COPY --from=builder /app/docs ./docs
+
 # ポート8080を開放
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Fix `/static/swagger-ui.html` 404 error after deployment
- Add missing static files and docs directories to Docker container

## Problem
After deployment, accessing `/static/swagger-ui.html` resulted in a 404 error because the Dockerfile was not copying the required static files (`static-files/` and `docs/` directories) to the container.

## Solution
Updated the Dockerfile to copy both directories from the builder stage to the runtime container, enabling access to:
- Swagger UI interface at `/static/swagger-ui.html`
- OpenAPI specification at `/docs/specs/index.yaml`

## Test plan
- [ ] Deploy changes to dev environment
- [ ] Verify `/static/swagger-ui.html` returns Swagger UI interface
- [ ] Verify Swagger UI can load API documentation from `/docs/specs/index.yaml`

🤖 Generated with [Claude Code](https://claude.ai/code)