### PR TITLE
Fix Docker build by removing docs/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,6 @@ tmp/
 .env
 .env.local
 tasks/
-docs/
 cmd/test_server/
 secret.yaml
 coverage.out


### PR DESCRIPTION
## Summary
- Remove `docs/` from `.dockerignore` to fix Docker build error
- This enables the Dockerfile to copy the docs directory containing OpenAPI specs

## Problem
The Docker build was failing with error:
```
COPY --from=builder /app/docs ./docs
ERROR: "/app/docs": not found
```

This occurred because the `docs/` directory was excluded in `.dockerignore`, preventing it from being available during the Docker build process.

## Solution
Removed the `docs/` line from `.dockerignore` to allow the directory to be included in the Docker build context.

## Test plan
- [x] Verify `docker build .` completes successfully
- [ ] Deploy and confirm `/docs/specs/index.yaml` is accessible
- [ ] Verify Swagger UI can load the API specification

🤖 Generated with [Claude Code](https://claude.ai/code)