### PR TITLE
Update Swagger UI to latest version 5.24.2

### DIFF
--- a/static-files/swagger-ui.html
+++ b/static-files/swagger-ui.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>Kyouen API Documentation</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.24.2/swagger-ui.css" />
 </head>
+
 <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.24.2/swagger-ui-bundle.js"></script>
     <script>
         SwaggerUIBundle({
             url: '/docs/specs/index.yaml',
@@ -18,4 +20,5 @@
         });
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
## Summary
- Update Swagger UI from version 3.25.0 to 5.24.2
- Updates both CSS and JavaScript bundle references to use the latest version

## Test plan
- [ ] Verify that Swagger UI loads correctly at http://localhost:8080/
- [ ] Check that the API documentation is properly displayed
- [ ] Ensure all API endpoints are accessible through the UI

🤖 Generated with [Claude Code](https://claude.ai/code)