### PR TITLE
Add RegistModel for stage registration tracking

### DIFF
--- a/docs/datastore-schema.json
+++ b/docs/datastore-schema.json
@@ -301,6 +301,60 @@
         ],
         "businessLogic": "Updates user.clearStageCount when new records are created"
       }
+    },
+    "RegistModel": {
+      "kind": "RegistModel",
+      "description": "Registration tracking for puzzle stages with automatic timestamp recording",
+      "keyPattern": {
+        "type": "incomplete",
+        "description": "Auto-generated integer keys",
+        "example": "datastore.IncompleteKey('RegistModel', nil)"
+      },
+      "properties": {
+        "stageInfo": {
+          "$ref": "#/definitions/datastoreKey",
+          "description": "Reference to KyouenPuzzle entity key",
+          "datastoreTag": "stageInfo",
+          "datastoreType": "*datastore.Key",
+          "goFieldName": "StageInfo"
+        },
+        "registDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the stage registration was recorded",
+          "datastoreTag": "registDate"
+        }
+      },
+      "required": [
+        "stageInfo",
+        "registDate"
+      ],
+      "indexes": [
+        {
+          "property": "stageInfo",
+          "description": "Index for retrieving registration records by stage"
+        },
+        {
+          "property": "registDate",
+          "description": "Index for chronological ordering of registrations"
+        }
+      ],
+      "constraints": {
+        "validStageReference": "stageInfo key must reference an existing KyouenPuzzle entity"
+      },
+      "usage": {
+        "description": "Audit trail and registration tracking for puzzle stages",
+        "operations": [
+          "create",
+          "read",
+          "query"
+        ],
+        "queryPatterns": [
+          "Filter by stageInfo to get registration record for specific stage",
+          "Order by registDate for chronological registration history"
+        ],
+        "businessLogic": "Automatically created when new KyouenPuzzle stages are registered"
+      }
     }
   },
   "relationships": {
@@ -320,6 +374,12 @@
       "type": "one-to-many",
       "description": "Each User can have multiple cleared stages",
       "relationship": "User clearStageCount is maintained as denormalized count"
+    },
+    "RegistModel_to_KyouenPuzzle": {
+      "type": "many-to-one",
+      "description": "Each RegistModel record references one KyouenPuzzle",
+      "foreignKey": "stageInfo",
+      "targetEntity": "KyouenPuzzle"
     }
   },
   "projectConfiguration": {

--- a/internal/datastore/models.go
+++ b/internal/datastore/models.go
@@ -37,3 +37,8 @@ type StageUser struct {
 	UserKey   *datastore.Key `datastore:"user"`
 	ClearDate time.Time      `datastore:"clearDate"`
 }
+
+type RegistModel struct {
+	StageInfo  *datastore.Key `datastore:"stageInfo"`
+	RegistDate time.Time      `datastore:"registDate"`
+}


### PR DESCRIPTION
## Summary
- PythonサーバーからRegistModelの登録処理をGoサーバーに移行
- ステージ登録の監査証跡を提供するRegistModelエンティティを追加
- 新しいステージ作成時に自動的にRegistModelレコードを作成

## 変更内容
- `RegistModel`構造体を`internal/datastore/models.go`に追加
- `createRegistModel`メソッドを`DatastoreService`に実装
- `CreateStage`メソッドでRegistModel作成処理を追加
- `docs/datastore-schema.json`にRegistModelエンティティ定義を追加

## Test plan
- [ ] ビルドとテストが成功することを確認
- [ ] 新しいステージ作成時にRegistModelレコードが作成されることを確認
- [ ] Datastoreスキーマドキュメントが更新されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)