### PR TITLE
Add recent_stages and activities APIs for web application

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -104,6 +104,10 @@ func setupRouter(app *App) *gin.Engine {
 		// Statistics endpoint
 		v2.GET("/statics", staticsHandler.GetStatics)
 
+		// New endpoints for web application
+		v2.GET("/recent_stages", stageHandler.GetRecentStages)
+		v2.GET("/activities", stageHandler.GetActivities)
+
 		// Stages endpoints
 		stages := v2.Group("/stages")
 		{

--- a/docs/specs/index.yaml
+++ b/docs/specs/index.yaml
@@ -328,6 +328,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /recent_stages:
+    get:
+      summary: 最新ステージ一覧取得
+      description: |
+        共円パズルゲームで最新の10ステージを取得します。
+        ステージは作成日時の逆順（最新から古い順）で返されます。
+        
+        **用途:**
+        - Webアプリケーションのトップページ表示
+        - 新しいステージの発見
+        - 最新コンテンツの確認
+      tags:
+        - stages
+      responses:
+        '200':
+          description: 最新ステージ取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Stage'
+        '500':
+          description: 内部サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /activities:
+    get:
+      summary: ユーザー活動一覧取得
+      description: |
+        ユーザーのステージクリア活動を取得します。
+        直近50件の活動をユーザーごとにグループ化して返します。
+        
+        **用途:**
+        - Webアプリケーションのアクティビティフィード
+        - ユーザーの活発な活動の確認
+        - コミュニティ機能の表示
+      tags:
+        - stages
+      responses:
+        '200':
+          description: ユーザー活動取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ActivityUser'
+        '500':
+          description: 内部サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /statics:
     get:
       summary: グローバルゲーム統計取得
@@ -564,6 +622,58 @@ components:
       example:
         count: 1234
         last_updated_at: "2024-01-15T10:30:00Z"
+
+    ActivityUser:
+      type: object
+      description: ユーザーのステージクリア活動情報
+      required:
+        - screen_name
+        - image
+        - cleared_stages
+      properties:
+        screen_name:
+          type: string
+          description: ユーザーのTwitterスクリーン名
+          example: "kyouen_player"
+        image:
+          type: string
+          description: ユーザーのプロフィール画像URL
+          example: "https://pbs.twimg.com/profile_images/123456789/profile_image.jpg"
+        cleared_stages:
+          type: array
+          description: ユーザーがクリアしたステージのリスト
+          items:
+            $ref: '#/components/schemas/ActivityStage'
+      example:
+        screen_name: "kyouen_player"
+        image: "https://pbs.twimg.com/profile_images/123456789/profile_image.jpg"
+        cleared_stages:
+          - stage_no: 125
+            clear_date: "2024-01-15T16:20:00Z"
+          - stage_no: 124
+            clear_date: "2024-01-15T15:10:00Z"
+
+    ActivityStage:
+      type: object
+      description: ユーザーがクリアしたステージ情報
+      required:
+        - stage_no
+        - clear_date
+      properties:
+        stage_no:
+          type: integer
+          format: int64
+          description: クリアされたステージ番号
+          minimum: 1
+          example: 125
+        clear_date:
+          type: string
+          format: date-time
+          description: ステージがクリアされたタイムスタンプ (UTC)
+          example: "2024-01-15T16:20:00Z"
+      example:
+        stage_no: 125
+        clear_date: "2024-01-15T16:20:00Z"
 
     Error:
       type: object

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -74,6 +74,20 @@ func (s *DatastoreService) GetStages(startStageNo int, limit int) ([]KyouenPuzzl
 	return stages, nil
 }
 
+func (s *DatastoreService) GetRecentStages(limit int) ([]KyouenPuzzle, error) {
+	var stages []KyouenPuzzle
+	query := datastore.NewQuery("KyouenPuzzle").
+		Order("-stageNo").
+		Limit(limit)
+
+	_, err := s.client.GetAll(s.ctx, query, &stages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recent stages: %w", err)
+	}
+
+	return stages, nil
+}
+
 func (s *DatastoreService) GetStageByNo(stageNo int) (*KyouenPuzzle, []*datastore.Key, error) {
 	var stages []KyouenPuzzle
 	query := datastore.NewQuery("KyouenPuzzle").FilterField("stageNo", "=", stageNo).Limit(1)
@@ -316,4 +330,39 @@ func (s *DatastoreService) IncrementUserClearCount(userKey *datastore.Key) error
 	})
 
 	return err
+}
+
+// GetRecentActivities gets recent user activities (stage completions)
+func (s *DatastoreService) GetRecentActivities(limit int) ([]StageUser, error) {
+	var stageUsers []StageUser
+	query := datastore.NewQuery("StageUser").
+		Order("-clearDate").
+		Limit(limit)
+
+	_, err := s.client.GetAll(s.ctx, query, &stageUsers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recent activities: %w", err)
+	}
+
+	return stageUsers, nil
+}
+
+// GetUserByKey gets a user by datastore key
+func (s *DatastoreService) GetUserByKey(userKey *datastore.Key) (*User, error) {
+	var user User
+	err := s.client.Get(s.ctx, userKey, &user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user by key: %w", err)
+	}
+	return &user, nil
+}
+
+// GetStageByKey gets a stage by datastore key
+func (s *DatastoreService) GetStageByKey(stageKey *datastore.Key) (*KyouenPuzzle, error) {
+	var stage KyouenPuzzle
+	err := s.client.Get(s.ctx, stageKey, &stage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stage by key: %w", err)
+	}
+	return &stage, nil
 }


### PR DESCRIPTION
## Summary
- Add GET /v2/recent_stages endpoint to retrieve latest 10 stages for web application top page
- Add GET /v2/activities endpoint to retrieve user activities grouped by user for activity feed
- Both APIs follow existing codebase patterns and are based on Python implementation reference

## Test plan
- [x] All existing tests pass
- [x] Code builds successfully without errors
- [x] OpenAPI specification updated with proper schemas
- [x] Endpoints follow existing REST API conventions

🤖 Generated with [Claude Code](https://claude.ai/code)