### PR TITLE
Fix stage clear endpoint HTTP method to PUT

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,7 +114,7 @@ func setupRouter(app *App) *gin.Engine {
 			stages.GET("", stageHandler.GetStages)
 			// Protected endpoints requiring authentication
 			stages.POST("", auth.FirebaseAuth(app.FirebaseService), stageHandler.CreateStage)
-			stages.POST("/:stageNo/clear", auth.FirebaseAuth(app.FirebaseService), stageHandler.ClearStage)
+			stages.PUT("/:stageNo/clear", auth.FirebaseAuth(app.FirebaseService), stageHandler.ClearStage)
 			stages.POST("/sync", auth.FirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
 		}
 


### PR DESCRIPTION
## Summary
- Change stage clear endpoint from POST to PUT method in cmd/server/main.go
- This aligns the implementation with OpenAPI specification (docs/specs/index.yaml)
- PUT method is more appropriate for updating stage clear status following RESTful conventions

## Test plan
- [ ] Verify the endpoint still works with PUT method
- [ ] Confirm OpenAPI specification alignment
- [ ] Test authentication and authorization still function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)