### PR TITLE
Add guest account support for non-authenticated users

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,8 +114,9 @@ func setupRouter(app *App) *gin.Engine {
 			stages.GET("", stageHandler.GetStages)
 			// Protected endpoints requiring authentication
 			stages.POST("", auth.FirebaseAuth(app.FirebaseService), stageHandler.CreateStage)
-			stages.PUT("/:stageNo/clear", auth.FirebaseAuth(app.FirebaseService), stageHandler.ClearStage)
-			stages.POST("/sync", auth.FirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
+			// These endpoints accept both authenticated and guest users
+			stages.PUT("/:stageNo/clear", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.ClearStage)
+			stages.POST("/sync", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
 		}
 
 		// Users endpoints

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,9 +114,9 @@ func setupRouter(app *App) *gin.Engine {
 			stages.GET("", stageHandler.GetStages)
 			// Protected endpoints requiring authentication
 			stages.POST("", auth.FirebaseAuth(app.FirebaseService), stageHandler.CreateStage)
-			// These endpoints accept both authenticated and guest users
+			stages.POST("/sync", auth.FirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
+			// This endpoint accepts both authenticated and guest users
 			stages.PUT("/:stageNo/clear", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.ClearStage)
-			stages.POST("/sync", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
 		}
 
 		// Users endpoints

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -28,78 +29,105 @@ type AuthenticatedUser struct {
 	TwitterUID string // Twitter User ID from custom claims
 }
 
-// FirebaseAuth creates a middleware that validates Firebase ID tokens
-func FirebaseAuth(firebaseService *datastore.FirebaseService) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Extract Bearer token from Authorization header
-		authHeader := c.GetHeader("Authorization")
-		if authHeader == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"error": "Authorization header is required",
-			})
-			c.Abort()
-			return
-		}
+// AuthResult represents the result of authentication attempt
+type AuthResult struct {
+	Success bool
+	User    *AuthenticatedUser
+	UID     string
+	Error   error
+}
 
-		// Check Bearer token format
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 || parts[0] != "Bearer" {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"error": "Authorization header must be Bearer token",
-			})
-			c.Abort()
-			return
-		}
+// authenticateToken performs Firebase token authentication
+func authenticateToken(firebaseService *datastore.FirebaseService, authHeader string) *AuthResult {
+	if authHeader == "" {
+		return &AuthResult{Success: false, Error: errors.New("authorization header is required")}
+	}
 
-		idToken := parts[1]
+	// Check Bearer token format
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return &AuthResult{Success: false, Error: errors.New("authorization header must be Bearer token")}
+	}
 
-		// Verify Firebase ID token
-		ctx := context.Background()
-		token, err := firebaseService.VerifyIDToken(ctx, idToken)
-		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"error": "Invalid Firebase ID token",
-			})
-			c.Abort()
-			return
-		}
+	idToken := parts[1]
 
-		// Get user information from Firebase Auth
-		userRecord, err := firebaseService.GetUserByUID(ctx, token.UID)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get user information",
-			})
-			c.Abort()
-			return
-		}
+	// Verify Firebase ID token
+	ctx := context.Background()
+	token, err := firebaseService.VerifyIDToken(ctx, idToken)
+	if err != nil {
+		return &AuthResult{Success: false, Error: errors.New("invalid Firebase ID token")}
+	}
 
-		// Extract Twitter UID from custom claims (if available)
-		twitterUID := ""
-		if claims, ok := token.Claims["firebase"].(map[string]interface{}); ok {
-			if identities, ok := claims["identities"].(map[string]interface{}); ok {
-				if twitterIds, ok := identities["twitter.com"].([]interface{}); ok && len(twitterIds) > 0 {
-					if twitterID, ok := twitterIds[0].(string); ok {
-						twitterUID = twitterID
-					}
+	// Get user information from Firebase Auth
+	userRecord, err := firebaseService.GetUserByUID(ctx, token.UID)
+	if err != nil {
+		return &AuthResult{Success: false, Error: errors.New("failed to get user information")}
+	}
+
+	// Extract Twitter UID from custom claims (if available)
+	twitterUID := ""
+	if claims, ok := token.Claims["firebase"].(map[string]interface{}); ok {
+		if identities, ok := claims["identities"].(map[string]interface{}); ok {
+			if twitterIds, ok := identities["twitter.com"].([]interface{}); ok && len(twitterIds) > 0 {
+				if twitterID, ok := twitterIds[0].(string); ok {
+					twitterUID = twitterID
 				}
 			}
 		}
+	}
 
-		// Create authenticated user object
-		authUser := &AuthenticatedUser{
-			UID:        token.UID,
-			Email:      userRecord.Email,
-			Name:       userRecord.DisplayName,
-			Picture:    userRecord.PhotoURL,
-			TwitterUID: twitterUID,
+	// Create authenticated user object
+	authUser := &AuthenticatedUser{
+		UID:        token.UID,
+		Email:      userRecord.Email,
+		Name:       userRecord.DisplayName,
+		Picture:    userRecord.PhotoURL,
+		TwitterUID: twitterUID,
+	}
+
+	return &AuthResult{Success: true, User: authUser, UID: token.UID}
+}
+
+// setAuthContextFromResult sets authentication information in gin context
+func setAuthContextFromResult(c *gin.Context, authResult *AuthResult) {
+	if authResult.Success {
+		c.Set(AuthUserKey, authResult.User)
+		c.Set(AuthUIDKey, authResult.UID)
+	} else {
+		c.Set(AuthUIDKey, GuestUID)
+	}
+}
+
+// FirebaseAuth creates a middleware that validates Firebase ID tokens
+func FirebaseAuth(firebaseService *datastore.FirebaseService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authResult := authenticateToken(firebaseService, c.GetHeader("Authorization"))
+
+		if !authResult.Success {
+			var statusCode int
+			if authResult.Error.Error() == "failed to get user information" {
+				statusCode = http.StatusInternalServerError
+			} else {
+				statusCode = http.StatusUnauthorized
+			}
+
+			c.JSON(statusCode, gin.H{"error": authResult.Error.Error()})
+			c.Abort()
+			return
 		}
 
-		// Store user information in context
-		c.Set(AuthUserKey, authUser)
-		c.Set(AuthUIDKey, token.UID)
+		setAuthContextFromResult(c, authResult)
+		c.Next()
+	}
+}
 
-		// Continue to next handler
+// OptionalFirebaseAuth creates a middleware that validates Firebase ID tokens but allows guest access
+func OptionalFirebaseAuth(firebaseService *datastore.FirebaseService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authResult := authenticateToken(firebaseService, c.GetHeader("Authorization"))
+		setAuthContextFromResult(c, authResult)
+
+		// Continue to next handler (never abort)
 		c.Next()
 	}
 }
@@ -122,78 +150,6 @@ func GetAuthenticatedUID(c *gin.Context) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-// OptionalFirebaseAuth creates a middleware that validates Firebase ID tokens but allows guest access
-func OptionalFirebaseAuth(firebaseService *datastore.FirebaseService) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Extract Bearer token from Authorization header
-		authHeader := c.GetHeader("Authorization")
-		if authHeader == "" {
-			// No authentication provided, set guest user
-			c.Set(AuthUIDKey, GuestUID)
-			c.Next()
-			return
-		}
-
-		// Check Bearer token format
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 || parts[0] != "Bearer" {
-			// Invalid format, set guest user
-			c.Set(AuthUIDKey, GuestUID)
-			c.Next()
-			return
-		}
-
-		idToken := parts[1]
-
-		// Verify Firebase ID token
-		ctx := context.Background()
-		token, err := firebaseService.VerifyIDToken(ctx, idToken)
-		if err != nil {
-			// Invalid token, set guest user
-			c.Set(AuthUIDKey, GuestUID)
-			c.Next()
-			return
-		}
-
-		// Get user information from Firebase Auth
-		userRecord, err := firebaseService.GetUserByUID(ctx, token.UID)
-		if err != nil {
-			// Failed to get user info, set guest user
-			c.Set(AuthUIDKey, GuestUID)
-			c.Next()
-			return
-		}
-
-		// Extract Twitter UID from custom claims (if available)
-		twitterUID := ""
-		if claims, ok := token.Claims["firebase"].(map[string]interface{}); ok {
-			if identities, ok := claims["identities"].(map[string]interface{}); ok {
-				if twitterIds, ok := identities["twitter.com"].([]interface{}); ok && len(twitterIds) > 0 {
-					if twitterID, ok := twitterIds[0].(string); ok {
-						twitterUID = twitterID
-					}
-				}
-			}
-		}
-
-		// Create authenticated user object
-		authUser := &AuthenticatedUser{
-			UID:        token.UID,
-			Email:      userRecord.Email,
-			Name:       userRecord.DisplayName,
-			Picture:    userRecord.PhotoURL,
-			TwitterUID: twitterUID,
-		}
-
-		// Store user information in context
-		c.Set(AuthUserKey, authUser)
-		c.Set(AuthUIDKey, token.UID)
-
-		// Continue to next handler
-		c.Next()
-	}
 }
 
 // IsGuestUser checks if the current user is a guest user

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -102,11 +102,11 @@ func (h *Handler) CreateStage(c *gin.Context) {
 }
 
 func (h *Handler) ClearStage(c *gin.Context) {
-	// Get authenticated user from context
+	// Get authenticated user from context (or use guest if not authenticated)
 	authUID, exists := auth.GetAuthenticatedUID(c)
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
-		return
+		// This should not happen with OptionalFirebaseAuth middleware, but just in case
+		authUID = auth.GuestUID
 	}
 
 	stageNo, err := strconv.Atoi(c.Param("stageNo"))
@@ -225,11 +225,11 @@ func (h *Handler) Login(c *gin.Context) {
 }
 
 func (h *Handler) SyncStages(c *gin.Context) {
-	// Get authenticated user from context
+	// Get authenticated user from context (or use guest if not authenticated)
 	authUID, exists := auth.GetAuthenticatedUID(c)
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
-		return
+		// This should not happen with OptionalFirebaseAuth middleware, but just in case
+		authUID = auth.GuestUID
 	}
 
 	var clientClearedStages []openapi.ClearedStage

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -225,11 +225,11 @@ func (h *Handler) Login(c *gin.Context) {
 }
 
 func (h *Handler) SyncStages(c *gin.Context) {
-	// Get authenticated user from context (or use guest if not authenticated)
+	// Get authenticated user from context
 	authUID, exists := auth.GetAuthenticatedUID(c)
 	if !exists {
-		// This should not happen with OptionalFirebaseAuth middleware, but just in case
-		authUID = auth.GuestUID
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return
 	}
 
 	var clientClearedStages []openapi.ClearedStage

--- a/internal/stage/service.go
+++ b/internal/stage/service.go
@@ -117,22 +117,10 @@ func (s *Service) ClearStage(stageNo int, stageData string, userUID string) (*da
 }
 
 func (s *Service) SyncStages(userUID string, clientClearedStages []openapi.ClearedStage) ([]datastoreservice.StageUser, error) {
-	// Get user from database (handle guest users)
-	var userKey *datastore.Key
-	var err error
-	
-	if auth.IsGuestUser(userUID) {
-		// Get or create guest user
-		_, userKey, err = s.datastoreService.GetOrCreateGuestUser()
-		if err != nil {
-			return nil, ErrUserNotFound
-		}
-	} else {
-		// Get regular user
-		_, userKey, err = s.datastoreService.GetUserByID(userUID)
-		if err != nil {
-			return nil, ErrUserNotFound
-		}
+	// Get authenticated user from database
+	_, userKey, err := s.datastoreService.GetUserByID(userUID)
+	if err != nil {
+		return nil, ErrUserNotFound
 	}
 	
 	// For each client cleared stage, create stage user relation if not exists

--- a/internal/stage/service.go
+++ b/internal/stage/service.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"strings"
 
-	"kyouen-server/internal/datastore"
+	"cloud.google.com/go/datastore"
+	"kyouen-server/internal/auth"
+	datastoreservice "kyouen-server/internal/datastore"
 	"kyouen-server/pkg/models"
 	"kyouen-server/internal/generated/openapi"
 )
@@ -22,18 +24,18 @@ var (
 )
 
 type Service struct {
-	datastoreService *datastore.DatastoreService
-	firebaseService  *datastore.FirebaseService
+	datastoreService *datastoreservice.DatastoreService
+	firebaseService  *datastoreservice.FirebaseService
 }
 
-func NewService(datastoreService *datastore.DatastoreService, firebaseService *datastore.FirebaseService) *Service {
+func NewService(datastoreService *datastoreservice.DatastoreService, firebaseService *datastoreservice.FirebaseService) *Service {
 	return &Service{
 		datastoreService: datastoreService,
 		firebaseService:  firebaseService,
 	}
 }
 
-func (s *Service) CreateStage(param openapi.NewStage, creatorName string) (*datastore.KyouenPuzzle, error) {
+func (s *Service) CreateStage(param openapi.NewStage, creatorName string) (*datastoreservice.KyouenPuzzle, error) {
 	// Validate stage using existing business logic
 	stage := *models.NewKyouenStage(int(param.Size), param.Stage)
 	
@@ -58,7 +60,7 @@ func (s *Service) CreateStage(param openapi.NewStage, creatorName string) (*data
 	}
 	
 	// Create stage with authenticated user as creator
-	newStage := datastore.KyouenPuzzle{
+	newStage := datastoreservice.KyouenPuzzle{
 		Size:    param.Size,
 		Stage:   param.Stage,
 		Creator: creatorName,
@@ -67,7 +69,7 @@ func (s *Service) CreateStage(param openapi.NewStage, creatorName string) (*data
 	return s.datastoreService.CreateStage(newStage)
 }
 
-func (s *Service) ClearStage(stageNo int, stageData string, userUID string) (*datastore.User, error) {
+func (s *Service) ClearStage(stageNo int, stageData string, userUID string) (*datastoreservice.User, error) {
 	// Validate clear stage using existing business logic
 	size := int(math.Sqrt(float64(len(stageData))))
 	paramKyouenStage := models.NewKyouenStage(size, stageData)
@@ -87,10 +89,22 @@ func (s *Service) ClearStage(stageNo int, stageData string, userUID string) (*da
 		return nil, ErrStageMismatch
 	}
 	
-	// Get user from database
-	user, userKey, err := s.datastoreService.GetUserByID(userUID)
-	if err != nil {
-		return nil, ErrUserNotFound
+	// Get user from database (handle guest users)
+	var user *datastoreservice.User
+	var userKey *datastore.Key
+	
+	if auth.IsGuestUser(userUID) {
+		// Get or create guest user
+		user, userKey, err = s.datastoreService.GetOrCreateGuestUser()
+		if err != nil {
+			return nil, ErrUserNotFound
+		}
+	} else {
+		// Get regular user
+		user, userKey, err = s.datastoreService.GetUserByID(userUID)
+		if err != nil {
+			return nil, ErrUserNotFound
+		}
 	}
 	
 	// Create stage user relation to record the clear
@@ -102,11 +116,23 @@ func (s *Service) ClearStage(stageNo int, stageData string, userUID string) (*da
 	return user, nil
 }
 
-func (s *Service) SyncStages(userUID string, clientClearedStages []openapi.ClearedStage) ([]datastore.StageUser, error) {
-	// Get user from database
-	_, userKey, err := s.datastoreService.GetUserByID(userUID)
-	if err != nil {
-		return nil, ErrUserNotFound
+func (s *Service) SyncStages(userUID string, clientClearedStages []openapi.ClearedStage) ([]datastoreservice.StageUser, error) {
+	// Get user from database (handle guest users)
+	var userKey *datastore.Key
+	var err error
+	
+	if auth.IsGuestUser(userUID) {
+		// Get or create guest user
+		_, userKey, err = s.datastoreService.GetOrCreateGuestUser()
+		if err != nil {
+			return nil, ErrUserNotFound
+		}
+	} else {
+		// Get regular user
+		_, userKey, err = s.datastoreService.GetUserByID(userUID)
+		if err != nil {
+			return nil, ErrUserNotFound
+		}
 	}
 	
 	// For each client cleared stage, create stage user relation if not exists


### PR DESCRIPTION
## 概要

ログインしていないユーザーのクリア進捗を保存できるゲストアカウント機能を実装し、**同期機能はセキュリティとデータ整合性のため制限付き**で提供します。

## 変更内容

### 1. ゲストアカウント実装
- 既存の本番データと互換性のある `GuestUID` 定数（"0"）を追加
- 本番環境互換形式の `GetOrCreateGuestUser` 関数を実装：
  - UserID: "0" 
  - ScreenName: "Guest"
  - Image: "http://kyouen.app/image/icon.png"
  - ゲストアカウントの自動作成または既存アカウント取得

### 2. 認証ミドルウェアの強化
- 認証済みユーザーとゲストユーザー両方を受け入れる `OptionalFirebaseAuth` ミドルウェアを追加
- 共通認証ロジックを関数として抽出：
  - `authenticateToken`: Firebase トークン検証
  - `AuthResult` 構造体: 標準化された認証結果
  - `setAuthContextFromResult`: 一貫したコンテキスト処理
- ミドルウェア間の重複コード約70行を削減

### 3. API エンドポイントのセキュリティ更新
- **`PUT /v2/stages/{stage_no}/clear`**: 認証済みユーザーとゲストユーザー両方を受け入れ
- **`POST /v2/stages/sync`**: **認証済みユーザーのみに制限**（ゲストアクセス不可）
  - `OptionalFirebaseAuth` から `FirebaseAuth` に変更
  - 同期ロジックからゲストユーザー処理を削除
  - 非認証リクエストに対して `401 Unauthorized` を返却

### 4. サービス層の改善
- `ClearStage` メソッドでゲストユーザーを適切に処理
- **`SyncStages` メソッドを簡素化**して認証済みユーザーのみを処理
- 認証済みユーザーの既存機能を維持

## セキュリティ考慮事項

**ゲストユーザーの同期機能を意図的に制限する理由：**
- 未検証のソースからの潜在的なデータ破損を防止
- データ整合性と監査証跡の維持
- フル機能アクセスのためのユーザー登録を促進
- 匿名ユーザー制限のベストプラクティスに準拠

## テスト計画

- [x] コードが正常にビルドされる
- [x] 既存のテストがすべて通る
- [x] ゲストアカウントの作成・取得が正常に動作
- [x] 認証ミドルウェアが両方のユーザータイプを適切に処理
- [x] 同期エンドポイントがゲストユーザーを適切に拒否
- [x] クリアエンドポイントが認証済みユーザーとゲストユーザー両方を受け入れ

## 備考

- 既存の本番データ（UserID "0" のゲストアカウント）と互換
- ゲストユーザーはステージクリア可能だが、デバイス間での進捗同期は不可
- 非認証ユーザーのクリアデータはすべて共有ゲストアカウントに関連付け
- 認証済みユーザーの既存ワークフローに破綻的変更なし
- フル同期機能のためのユーザー登録を促進

🤖 Generated with [Claude Code](https://claude.ai/code)