### PR TITLE
chore: replace alpine with distroless base image for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server ./cmd/server
 
 # 実行ステージ
-FROM alpine:3.21
+FROM gcr.io/distroless/static-debian12:nonroot
 
-# CA証明書を追加（HTTPS通信のため）
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+WORKDIR /app
 
 # ビルドしたバイナリをコピー
 COPY --from=builder /app/server .

--- a/Dockerfile.seed
+++ b/Dockerfile.seed
@@ -14,11 +14,9 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o seed ./cmd/seed
 
 # 実行ステージ
-FROM alpine:3.21
+FROM gcr.io/distroless/static-debian12:nonroot
 
-# CA証明書を追加（HTTPS通信のため）
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+WORKDIR /app
 
 # ビルドしたバイナリをコピー
 COPY --from=builder /app/seed .


### PR DESCRIPTION
## Summary

- `Dockerfile` と `Dockerfile.seed` の実行ステージのベースイメージを `alpine:3.21` から `gcr.io/distroless/static-debian12:nonroot` に変更
- CA証明書の `apk` インストールを削除（distrolessにCA証明書が内包されているため不要）
- `WORKDIR` を `/root/` から `/app` に変更（nonrootユーザー向けの適切なパス）

## 背景

`alpine` イメージにはシェルやパッケージマネージャーが含まれており、脆弱性の攻撃面となりえます。`distroless/static` イメージを使うことで：

- シェルが存在しないため、シェルインジェクション攻撃が不可能
- パッケージマネージャーがないため、コンテナ内でのパッケージインストールが不可能
- OS由来の脆弱なパッケージが最小限（CA証明書・tzdata のみ）
- `:nonroot` タグにより、rootではないユーザー（UID 65532）で実行される

`CGO_ENABLED=0` で静的バイナリをビルドしているため、glibc などの依存がなく `distroless/static` と完全に適合します。

## Test plan

- [ ] `docker build -t kyouen-server .` でビルドが成功することを確認
- [ ] `docker build -f Dockerfile.seed -t kyouen-seed .` でビルドが成功することを確認
- [ ] CI の Docker ビルドが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)