### PR TITLE
feat: migrate legacy Python user records on first Firebase login

### DIFF
--- a/docs/adr/002-python-user-migration.md
+++ b/docs/adr/002-python-user-migration.md
@@ -1,0 +1,67 @@
+# ADR 002: kyouen-python からの User レコードマイグレーション方式
+
+## ステータス
+
+採用済み (2026-04-11)
+
+## コンテキスト
+
+kyouen-python (旧 Google App Engine / Python アプリ) から kyouen-server (Go / Cloud Run) への移行において、DatastoreのUserエンティティのキー構造が異なる問題が発生した。
+
+| システム | キー形式 | userId フィールド |
+|---|---|---|
+| kyouen-python | `'KEY' + Twitter UID` | Twitter UID |
+| kyouen-server | `'KEY' + Firebase UID` | Firebase UID |
+
+Firebase Auth 経由の Twitter ログインでは、Firebase UID と Twitter UID は異なる値となる。
+そのため、Go側がログイン処理を行う際に既存の Python 時代のエンティティを発見できず、新規ユーザーとして作成してしまい、`clearStageCount` や `StageUser` レコードが失われるという問題があった。
+
+## 決定事項
+
+**初回ログイン時に自動マイグレーションを実行する** ことにした。
+
+`CreateOrUpdateUserFromFirebase` 関数において、Firebase UID でユーザーが見つからない場合、Twitter UID による追加検索を行い、レガシーエンティティが見つかれば透過的にマイグレーションする。
+
+### マイグレーションの処理内容
+
+トランザクション内（原子性を保証）:
+1. 旧エンティティ (`'KEY' + twitterUID`) を読み取り、`clearStageCount` を取得
+2. 新エンティティ (`'KEY' + firebaseUID`) を作成（`clearStageCount` 引き継ぎ）
+3. `UserMigration` レコードを作成（監査ログ）
+4. 旧エンティティを削除
+
+トランザクション外（Datastore の 25 エンティティグループ制限のため）:
+5. 旧ユーザーキーを参照する `StageUser` レコードを新キーに更新
+
+## 検討した代替案
+
+### 案 A: バッチマイグレーションスクリプト
+
+デプロイ前に全 User エンティティを一括マイグレーションする。
+
+**却下理由**: Firebase UID と Twitter UID の対応関係を事前に取得するためには全ユーザーを Firebase Auth に問い合わせる必要があり、大量の API 呼び出しが発生する。また、実際にログインしないユーザーのデータまで移行する必要はない。
+
+### 案 B: 両キーを並行サポート
+
+Firebase UID と Twitter UID の両方でユーザーを検索し、両方のエンティティを保持する。
+
+**却下理由**: データの二重管理が発生し、`clearStageCount` の整合性維持が複雑になる。
+
+### 案 C: 採用案（初回ログイン時の自動マイグレーション）
+
+**採用理由**:
+- 実際にログインするユーザーのみマイグレーション対象となり効率的
+- ユーザー側の操作不要で透過的に行われる
+- `UserMigration` レコードによりマイグレーション状況の監査が可能
+
+## 影響
+
+- `internal/datastore/datastore.go`: `MigrateLegacyUser`、`migrateStageUserRecords` の追加、`CreateOrUpdateUserFromFirebase` の修正
+- `internal/datastore/models.go`: `UserMigration` 構造体の追加
+- `docs/datastore-schema.json`: `UserMigration` Kind の定義追加
+- `docs/auth-data-relations.md`: マイグレーションフローの説明追加
+
+## トレードオフ・注意事項
+
+- `StageUser` レコードの更新はトランザクション外のため、処理中断時に一部のレコードが旧キーを参照したままになる可能性がある。ただし `clearStageCount` はトランザクション内で正しく引き継がれており、実質的なデータロスは発生しない。`UserMigration` レコードを参照することで、後から旧キーを特定して再修復も可能。
+- `twitterUID` が空（将来的な非 Twitter プロバイダ）の場合は、レガシー検索をスキップして通常の新規作成フローに入る。

--- a/docs/auth-data-relations.md
+++ b/docs/auth-data-relations.md
@@ -101,3 +101,47 @@ sequenceDiagram
     Datastore-->>Server: User エンティティ
     Server-->>Client: ユーザー情報レスポンス
 ```
+
+## kyouen-python からのマイグレーションフロー
+
+kyouen-python (旧Pythonアプリ) では、UserエンティティのキーとしてTwitter UIDを使用していた。
+Firebase Auth 移行後は Firebase UID をキーとして使用するため、初回ログイン時に自動マイグレーションが実行される。
+
+### キー構造の違い
+
+| システム | キー形式 | 例 |
+|---|---|---|
+| kyouen-python (旧) | `'KEY' + Twitter UID` | `KEY12345` |
+| kyouen-server (現) | `'KEY' + Firebase UID` | `KEYabc123def` |
+
+### マイグレーションフロー
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant Datastore
+
+    Client->>Server: POST /login (初回ログイン)
+    Server->>Datastore: GetUserByID(firebaseUID) → 見つからない
+    Server->>Datastore: GetUserByID(twitterUID) → 旧エンティティ発見
+    Note over Server,Datastore: MigrateLegacyUser をトランザクション実行
+    Server->>Datastore: Put User("KEY" + firebaseUID)<br/>clearStageCount を引き継ぎ
+    Server->>Datastore: Put UserMigration<br/>(旧キー→新キーの対応を記録)
+    Server->>Datastore: Delete User("KEY" + twitterUID)
+    Server->>Datastore: StageUser レコードの UserKey を新キーに更新
+    Server-->>Client: ユーザー情報レスポンス
+```
+
+### UserMigration エンティティ
+
+マイグレーション実行時に `UserMigration` Kind のレコードが作成される。
+このレコードにより、どのユーザーがいつマイグレーションされたかを追跡できる。
+
+| フィールド | 内容 |
+|---|---|
+| `oldKey` | 旧キー名 (例: `KEY12345`) |
+| `newKey` | 新キー名 (例: `KEYabc123def`) |
+| `twitterUid` | Twitter UID |
+| `firebaseUid` | Firebase UID |
+| `migratedAt` | マイグレーション実行日時 |

--- a/docs/datastore-schema.json
+++ b/docs/datastore-schema.json
@@ -302,6 +302,63 @@
         "businessLogic": "Updates user.clearStageCount when new records are created"
       }
     },
+    "UserMigration": {
+      "kind": "UserMigration",
+      "description": "Audit log for user record migrations from the legacy Python app (kyouen-python) to the Go server. Records the mapping from old Twitter UID-based keys to new Firebase UID-based keys.",
+      "keyPattern": {
+        "type": "incomplete",
+        "description": "Auto-generated integer keys",
+        "example": "datastore.IncompleteKey('UserMigration', nil)"
+      },
+      "properties": {
+        "oldKey": {
+          "type": "string",
+          "description": "Legacy Datastore key name used by the Python app: 'KEY' + Twitter UID (e.g., 'KEY12345')",
+          "datastoreTag": "oldKey",
+          "maxLength": 128
+        },
+        "newKey": {
+          "type": "string",
+          "description": "New Datastore key name used by the Go server: 'KEY' + Firebase UID (e.g., 'KEYabc123def')",
+          "datastoreTag": "newKey",
+          "maxLength": 256
+        },
+        "twitterUid": {
+          "type": "string",
+          "description": "Twitter User ID that was used as the key in the legacy system",
+          "datastoreTag": "twitterUid",
+          "maxLength": 50
+        },
+        "firebaseUid": {
+          "type": "string",
+          "description": "Firebase UID assigned by Firebase Auth for the same Twitter account",
+          "datastoreTag": "firebaseUid",
+          "maxLength": 128
+        },
+        "migratedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the migration was executed (on first login after migration)",
+          "datastoreTag": "migratedAt"
+        }
+      },
+      "required": [
+        "oldKey",
+        "newKey",
+        "twitterUid",
+        "firebaseUid",
+        "migratedAt"
+      ],
+      "indexes": [],
+      "usage": {
+        "description": "Audit trail for the one-time migration of User records from kyouen-python (Twitter UID keys) to kyouen-server (Firebase UID keys). Created automatically during the user's first login after migration.",
+        "operations": [
+          "create",
+          "read"
+        ],
+        "lifecycle": "Created once per user when a legacy User entity is detected and migrated. Never updated or deleted."
+      }
+    },
     "RegistModel": {
       "kind": "RegistModel",
       "description": "Registration tracking for puzzle stages with automatic timestamp recording",

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -215,12 +215,96 @@ func (s *DatastoreService) UpsertUser(user User, userID string) (*User, error) {
 	return &user, nil
 }
 
+// MigrateLegacyUser migrates a legacy Python-era user (keyed by Twitter UID) to a new Firebase UID-based key.
+// It preserves clearStageCount, records the migration in UserMigration, and re-points StageUser records.
+func (s *DatastoreService) MigrateLegacyUser(firebaseUID, screenName, image, twitterUID string) (*User, error) {
+	oldKey := datastore.NameKey("User", "KEY"+twitterUID, nil)
+	newKey := datastore.NameKey("User", "KEY"+firebaseUID, nil)
+
+	var migratedUser User
+
+	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+		// 1. 旧エンティティを読み取り
+		var oldUser User
+		if err := tx.Get(oldKey, &oldUser); err != nil {
+			return fmt.Errorf("failed to get legacy user: %w", err)
+		}
+
+		// 2. clearStageCount を引き継いで新エンティティを作成
+		migratedUser = User{
+			UserID:          firebaseUID,
+			ScreenName:      screenName,
+			Image:           image,
+			TwitterUID:      twitterUID,
+			ClearStageCount: oldUser.ClearStageCount,
+		}
+		if _, err := tx.Put(newKey, &migratedUser); err != nil {
+			return fmt.Errorf("failed to put migrated user: %w", err)
+		}
+
+		// 3. UserMigration レコードを作成
+		migration := UserMigration{
+			OldKey:      "KEY" + twitterUID,
+			NewKey:      "KEY" + firebaseUID,
+			TwitterUID:  twitterUID,
+			FirebaseUID: firebaseUID,
+			MigratedAt:  time.Now(),
+		}
+		migrationKey := datastore.IncompleteKey("UserMigration", nil)
+		if _, err := tx.Put(migrationKey, &migration); err != nil {
+			return fmt.Errorf("failed to save UserMigration record: %w", err)
+		}
+
+		// 4. 旧エンティティを削除
+		if err := tx.Delete(oldKey); err != nil {
+			return fmt.Errorf("failed to delete legacy user: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to migrate legacy user: %w", err)
+	}
+
+	// 5. StageUser レコードのキーを更新（トランザクション外: 25エンティティグループ制限のため）
+	s.migrateStageUserRecords(oldKey, newKey)
+
+	return &migratedUser, nil
+}
+
+// migrateStageUserRecords updates StageUser records that reference the old user key to point to the new key.
+func (s *DatastoreService) migrateStageUserRecords(oldUserKey, newUserKey *datastore.Key) {
+	query := datastore.NewQuery("StageUser").FilterField("user", "=", oldUserKey)
+	var stageUsers []StageUser
+	keys, err := s.client.GetAll(s.ctx, query, &stageUsers)
+	if err != nil {
+		fmt.Printf("Warning: failed to query StageUser records for migration: %v\n", err)
+		return
+	}
+
+	for i := range stageUsers {
+		stageUsers[i].UserKey = newUserKey
+		if _, err := s.client.Put(s.ctx, keys[i], &stageUsers[i]); err != nil {
+			fmt.Printf("Warning: failed to migrate StageUser record %v: %v\n", keys[i], err)
+		}
+	}
+}
+
 // CreateOrUpdateUserFromFirebase creates or updates a user from Firebase authentication data
 func (s *DatastoreService) CreateOrUpdateUserFromFirebase(firebaseUID, screenName, image, twitterUID string) (*User, error) {
 	// Try to get existing user
 	existingUser, _, err := s.GetUserByID(firebaseUID)
 	if err != nil {
-		// User doesn't exist, create new one
+		// Firebase UID でユーザーが見つからない場合、レガシーユーザー（Twitter UID キー）を検索
+		if twitterUID != "" {
+			legacyUser, _, legacyErr := s.GetUserByID(twitterUID)
+			if legacyErr == nil && legacyUser != nil {
+				// Python時代のユーザーが見つかった → マイグレーション実行
+				return s.MigrateLegacyUser(firebaseUID, screenName, image, twitterUID)
+			}
+		}
+
+		// レガシーユーザーも存在しない → 新規作成
 		newUser := User{
 			UserID:          firebaseUID,
 			ScreenName:      screenName,

--- a/internal/datastore/models.go
+++ b/internal/datastore/models.go
@@ -42,3 +42,11 @@ type RegistModel struct {
 	StageInfo  *datastore.Key `datastore:"stageInfo"`
 	RegistDate time.Time      `datastore:"registDate"`
 }
+
+type UserMigration struct {
+	OldKey      string    `datastore:"oldKey"`      // 旧キー名 (例: "KEY12345")
+	NewKey      string    `datastore:"newKey"`      // 新キー名 (例: "KEYabc123def")
+	TwitterUID  string    `datastore:"twitterUid"`  // Twitter UID
+	FirebaseUID string    `datastore:"firebaseUid"` // Firebase UID
+	MigratedAt  time.Time `datastore:"migratedAt"`  // マイグレーション実行日時
+}


### PR DESCRIPTION
## Summary

- kyouen-python の User エンティティ（キー: `'KEY' + Twitter UID`）を kyouen-server（キー: `'KEY' + Firebase UID`）に自動マイグレーションする機能を実装
- 初回ログイン時に透過的にマイグレーションが実行され、`clearStageCount` と `StageUser` レコードが引き継がれる
- `UserMigration` Kind を新設し、マイグレーション履歴を監査ログとして記録

## 変更内容

### コード
- `internal/datastore/models.go`: `UserMigration` 構造体を追加
- `internal/datastore/datastore.go`:
  - `MigrateLegacyUser`: レガシーエンティティを新キーにトランザクションで移行
  - `migrateStageUserRecords`: `StageUser` レコードの参照先キーを更新
  - `CreateOrUpdateUserFromFirebase`: Firebase UID で見つからない場合に Twitter UID でレガシー検索を追加

### ドキュメント
- `docs/datastore-schema.json`: `UserMigration` Kind の定義を追加
- `docs/auth-data-relations.md`: マイグレーションフローの説明・シーケンス図を追加
- `docs/adr/002-python-user-migration.md`: アーキテクチャ決定記録を新規作成

## マイグレーションフロー

```
POST /v2/users/login (初回ログイン)
  ↓
GetUserByID(firebaseUID) → 見つからない
  ↓
GetUserByID(twitterUID) → 旧エンティティ発見
  ↓ [トランザクション]
  Put User("KEY" + firebaseUID)  ← clearStageCount 引き継ぎ
  Put UserMigration              ← 監査ログ記録
  Delete User("KEY" + twitterUID)
  ↓ [トランザクション外]
  StageUser.UserKey を新キーに更新
```

## Test plan

- [ ] `go build ./...` が通ること
- [ ] `go test ./...` が通ること（既存テストへの影響がないこと）
- [ ] Datastore エミュレーターでの統合確認:
  1. レガシー形式の User エンティティを作成（`KEY12345`, `clearStageCount: 5`）
  2. Firebase UID `firebase_abc`, Twitter UID `12345` でログイン
  3. 新エンティティ（`KEYfirebase_abc`）に `clearStageCount: 5` が引き継がれること
  4. 旧エンティティ（`KEY12345`）が削除されていること
  5. `UserMigration` レコードが作成されていること
  6. `StageUser` レコードが新キーを参照していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)