### PR TITLE
feat: add Claude Code skill for generating Apple Sign In client_secret JWT

### DIFF
--- a/.claude/commands/gen-apple-client-secret.md
+++ b/.claude/commands/gen-apple-client-secret.md
@@ -1,0 +1,44 @@
+---
+allowed-tools: Bash(uv run .claude/scripts/gen_apple_client_secret.py:*), Read, Edit
+description: Apple Sign In 用の client_secret JWT を生成する
+---
+
+## タスク
+
+Apple Sign In の `client_secret`（JWT）を生成して `terraform/envs/$ENV/terraform.tfvars` に書き込む。
+
+## 事前確認
+
+まず以下のファイルを読んで現在の設定値を確認する：
+- `terraform/envs/prod/terraform.tfvars`（または指定された環境）
+
+確認すべき値：
+- `apple_client_id`（= Service ID、JWT の `sub` クレームに使う）
+- 既存の `apple_client_secret` の JWT ヘッダー部分をデコードして `kid`（Key ID）を確認
+
+## ユーザーへの確認
+
+生成前に以下を確認する：
+
+1. **環境**: dev / prod のどちら？
+2. **`.p8` ファイルのパス**: Apple Developer Portal からダウンロードした秘密鍵ファイル（例: `~/Downloads/AuthKey_XXXXXXXXXX.p8`）
+3. **Team ID**: Apple Developer Portal のメンバーシップ画面に表示される 10 桁の英数字
+
+## JWT 生成
+
+以下のコマンドで生成する：
+
+```bash
+uv run .claude/scripts/gen_apple_client_secret.py \
+    --p8 <path_to_AuthKey.p8> \
+    --team-id <TEAM_ID> \
+    --key-id <KEY_ID> \
+    --client-id <apple_client_id の値>
+```
+
+出力の `=== JWT Payload (verification) ===` セクションで `sub` が `apple_client_id` と一致していることを確認する。
+
+## tfvars への書き込み
+
+生成した JWT（`=== Generated client_secret ===` の値）を
+`terraform/envs/$ENV/terraform.tfvars` の `apple_client_secret` の値に Edit ツールで更新する。

--- a/.claude/scripts/gen_apple_client_secret.py
+++ b/.claude/scripts/gen_apple_client_secret.py
@@ -1,0 +1,67 @@
+# /// script
+# dependencies = [
+#   "PyJWT==2.12.1",
+#   "cryptography==46.0.7",
+# ]
+# ///
+"""
+Apple Sign In 用の client_secret JWT を生成するスクリプト。
+
+Usage:
+    uv run .claude/scripts/gen_apple_client_secret.py \
+        --p8 <path_to_AuthKey.p8> \
+        --team-id <TEAM_ID> \
+        --key-id <KEY_ID> \
+        --client-id <SERVICE_ID>
+"""
+
+import argparse
+import base64
+import json
+import time
+
+import jwt
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+
+def generate(p8_path: str, team_id: str, key_id: str, client_id: str) -> str:
+    with open(p8_path, "rb") as f:
+        key = load_pem_private_key(f.read(), password=None)
+
+    now = int(time.time())
+    payload = {
+        "iss": team_id,
+        "iat": now,
+        "exp": now + 15777000,  # 約6ヶ月（Apple の上限）
+        "aud": "https://appleid.apple.com",
+        "sub": client_id,
+    }
+    return jwt.encode(payload, key, algorithm="ES256", headers={"kid": key_id})
+
+
+def decode_payload(token: str) -> dict:
+    payload_b64 = token.split(".")[1]
+    padding = 4 - len(payload_b64) % 4
+    payload_b64 += "=" * (padding % 4)
+    return json.loads(base64.b64decode(payload_b64))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate Apple Sign In client_secret JWT")
+    parser.add_argument("--p8", required=True, help=".p8 秘密鍵ファイルのパス")
+    parser.add_argument("--team-id", required=True, help="Apple Developer Team ID")
+    parser.add_argument("--key-id", required=True, help="Key ID（.p8 ファイル名の AuthKey_XXXXXXXXXX の部分）")
+    parser.add_argument("--client-id", required=True, help="Service ID（apple_client_id）")
+    args = parser.parse_args()
+
+    token = generate(args.p8, args.team_id, args.key_id, args.client_id)
+
+    print("=== Generated client_secret ===")
+    print(token)
+    print()
+    print("=== JWT Payload (verification) ===")
+    print(json.dumps(decode_payload(token), indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Apple Sign In の `client_secret`（JWT）を生成する Claude Code スキル `/gen-apple-client-secret` を追加
- `.claude/scripts/gen_apple_client_secret.py`: PEP 723 inline metadata でバージョン固定（`PyJWT==2.12.1`, `cryptography==46.0.7`）
- `.claude/commands/gen-apple-client-secret.md`: スキル定義（`allowed-tools` でスクリプト実行のみ許可）

## Test plan

- [ ] `/gen-apple-client-secret` を実行して JWT が生成されることを確認
- [ ] 生成された JWT の `sub` が `apple_client_id` と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)