### PR TITLE
chore: add Datastore composite index for StageUser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,15 @@ DATASTORE_EMULATOR_HOST=localhost:9098 go run cmd/seed/main.go
 DATASTORE_EMULATOR_HOST=localhost:9098 FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 go run cmd/server/main.go
 ```
 
+### Datastore インデックス管理
+```bash
+# DEV環境にインデックスを反映
+gcloud datastore indexes create index.yaml --project=api-project-732262258565
+
+# 本番環境にインデックスを反映
+gcloud datastore indexes create index.yaml --project=my-android-server
+```
+
 ### OpenAPI コード生成
 ```bash
 # OpenAPI仕様からGoモデルを生成（Docker経由）

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ terraform apply -var-file="terraform.tfvars"
 
 詳細は [terraform/README.md](./terraform/README.md) を参照してください。
 
+### Datastore インデックス管理
+
+複合インデックスは `index.yaml` で定義し、以下のコマンドで反映します。
+
+```bash
+# DEV環境
+gcloud datastore indexes create index.yaml --project=api-project-732262258565
+
+# 本番環境
+gcloud datastore indexes create index.yaml --project=my-android-server
+```
+
 ## 🚀 CI/CD
 
 GitHub Actionsによる自動CI/CDを設定済み：

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,5 @@
+indexes:
+- kind: StageUser
+  properties:
+  - name: user
+  - name: clearDate


### PR DESCRIPTION
## Summary
- `index.yaml` を追加し、`StageUser` エンティティの `user` + `clearDate` による複合インデックスを定義
- 単一プロパティインデックス（`KyouenPuzzle.stageNo`）は Datastore が自動構築するため不要として除外

## Test plan
- [ ] DEV 環境の Datastore でインデックスが正常に作成されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)