### PR TITLE
feat: GET /v2/stages にクリア情報を追加（ログイン時）

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -111,7 +111,7 @@ func setupRouter(app *App) *gin.Engine {
 		// Stages endpoints
 		stages := v2.Group("/stages")
 		{
-			stages.GET("", stageHandler.GetStages)
+			stages.GET("", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.GetStages)
 			// Protected endpoints requiring authentication
 			stages.POST("", auth.FirebaseAuth(app.FirebaseService), stageHandler.CreateStage)
 			stages.POST("/sync", auth.FirebaseAuth(app.FirebaseService), stageHandler.SyncStages)

--- a/docs/specs/index.yaml
+++ b/docs/specs/index.yaml
@@ -151,8 +151,12 @@ paths:
       description: |
         共円パズルステージのページネーション対応一覧を取得します。
         ステージはステージ番号順に並び、開始位置でフィルタできます。
+        認証済みユーザーの場合、各ステージのクリア状況も返却されます。
       tags:
         - stages
+      security:
+        - bearerAuth: []
+        - {}
       parameters:
         - name: start_stage_no
           in: query
@@ -553,12 +557,17 @@ components:
           format: date-time
           description: ステージ登録タイムスタンプ (UTC)
           example: "2024-01-15T10:30:00Z"
+        cleared:
+          type: boolean
+          description: ログインユーザーがこのステージをクリア済みかどうか（ログイン時のみ返却）
+          example: true
       example:
         stage_no: 12
         size: 6
         stage: "000000010000001100001100000000001000"
         creator: "noboru"
         regist_date: "2024-01-15T10:30:00Z"
+        cleared: true
     NewStage:
       type: object
       description: 新しい共円パズルステージ作成用データ

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -59,19 +59,32 @@ func (s *DatastoreService) GetSummary() (*KyouenPuzzleSummary, error) {
 }
 
 // Stages operations
-func (s *DatastoreService) GetStages(startStageNo int, limit int) ([]KyouenPuzzle, error) {
+func (s *DatastoreService) GetStages(startStageNo int, limit int) ([]KyouenPuzzle, []*datastore.Key, error) {
 	var stages []KyouenPuzzle
 	query := datastore.NewQuery("KyouenPuzzle").
 		FilterField("stageNo", ">=", startStageNo).
 		Order("stageNo").
 		Limit(limit)
 
-	_, err := s.client.GetAll(s.ctx, query, &stages)
+	keys, err := s.client.GetAll(s.ctx, query, &stages)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stages: %w", err)
+		return nil, nil, fmt.Errorf("failed to get stages: %w", err)
 	}
 
-	return stages, nil
+	return stages, keys, nil
+}
+
+// GetClearedStageKeyIDs returns a set of Datastore key IDs for stages cleared by the given user.
+func (s *DatastoreService) GetClearedStageKeyIDs(userKey *datastore.Key) (map[int64]bool, error) {
+	stageUsers, err := s.GetClearedStagesByUser(userKey)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[int64]bool, len(stageUsers))
+	for _, su := range stageUsers {
+		result[su.StageKey.ID] = true
+	}
+	return result, nil
 }
 
 func (s *DatastoreService) GetRecentStages(limit int) ([]KyouenPuzzle, error) {

--- a/internal/generated/openapi/model_stage.go
+++ b/internal/generated/openapi/model_stage.go
@@ -27,7 +27,7 @@ type Stage struct {
 	// グリッドサイズ（ステージはsize x sizeの正方形）
 	Size int64 `json:"size"`
 
-	// 文字列表現でのステージ設定。 形式: size²文字で以下を表す: - \"0\" = 空のセル - \"1\" = 黒石（パズル要素） - \"2\" = 白石（ユーザー配置） 
+	// 文字列表現でのステージ設定。 形式: size²文字で以下を表す: - \"0\" = 空のセル - \"1\" = 黒石（パズル要素） - \"2\" = 白石（ユーザー配置）
 	Stage string `json:"stage" validate:"regexp=^[012]+$"`
 
 	// ステージ作成者のユーザー名
@@ -35,6 +35,9 @@ type Stage struct {
 
 	// ステージ登録タイムスタンプ (UTC)
 	RegistDate time.Time `json:"regist_date"`
+
+	// ログインユーザーがクリア済みかどうか（ログイン時のみ返却）
+	Cleared *bool `json:"cleared,omitempty"`
 }
 
 // AssertStageRequired checks if the required fields are not zero-ed

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -41,22 +41,37 @@ func (h *Handler) GetStages(c *gin.Context) {
 		limit = 100
 	}
 
-	stages, err := h.datastoreService.GetStages(startStageNo, limit)
+	stages, stageKeys, err := h.datastoreService.GetStages(startStageNo, limit)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
+	// If authenticated (non-guest), fetch cleared stage key IDs for this user.
+	var clearedKeyIDs map[int64]bool
+	authUID, uidExists := auth.GetAuthenticatedUID(c)
+	if uidExists && !auth.IsGuestUser(authUID) {
+		_, userKey, userErr := h.datastoreService.GetUserByID(authUID)
+		if userErr == nil {
+			clearedKeyIDs, _ = h.datastoreService.GetClearedStageKeyIDs(userKey)
+		}
+	}
+
 	// Convert to response format
 	stageList := []openapi.Stage{}
-	for _, stage := range stages {
-		stageList = append(stageList, openapi.Stage{
+	for i, stage := range stages {
+		s := openapi.Stage{
 			StageNo:    stage.StageNo,
 			Size:       stage.Size,
 			Stage:      stage.Stage,
 			Creator:    stage.Creator,
 			RegistDate: stage.RegistDate,
-		})
+		}
+		if clearedKeyIDs != nil {
+			cleared := clearedKeyIDs[stageKeys[i].ID]
+			s.Cleared = &cleared
+		}
+		stageList = append(stageList, s)
 	}
 
 	c.JSON(http.StatusOK, stageList)

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -41,20 +41,11 @@ func (h *Handler) GetStages(c *gin.Context) {
 		limit = 100
 	}
 
-	stages, stageKeys, err := h.datastoreService.GetStages(startStageNo, limit)
+	authUID, _ := auth.GetAuthenticatedUID(c)
+	stages, stageKeys, clearedKeyIDs, err := h.stageService.GetStages(startStageNo, limit, authUID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
-	}
-
-	// If authenticated (non-guest), fetch cleared stage key IDs for this user.
-	var clearedKeyIDs map[int64]bool
-	authUID, uidExists := auth.GetAuthenticatedUID(c)
-	if uidExists && !auth.IsGuestUser(authUID) {
-		_, userKey, userErr := h.datastoreService.GetUserByID(authUID)
-		if userErr == nil {
-			clearedKeyIDs, _ = h.datastoreService.GetClearedStageKeyIDs(userKey)
-		}
 	}
 
 	// Convert to response format

--- a/internal/stage/service.go
+++ b/internal/stage/service.go
@@ -41,6 +41,23 @@ func NewService(datastoreService *datastoreservice.DatastoreService, firebaseSer
 	}
 }
 
+func (s *Service) GetStages(startStageNo, limit int, authUID string) ([]datastoreservice.KyouenPuzzle, []*datastore.Key, map[int64]bool, error) {
+	stages, stageKeys, err := s.datastoreService.GetStages(startStageNo, limit)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var clearedKeyIDs map[int64]bool
+	if authUID != "" && !auth.IsGuestUser(authUID) {
+		_, userKey, userErr := s.datastoreService.GetUserByID(authUID)
+		if userErr == nil {
+			clearedKeyIDs, _ = s.datastoreService.GetClearedStageKeyIDs(userKey)
+		}
+	}
+
+	return stages, stageKeys, clearedKeyIDs, nil
+}
+
 func (s *Service) CreateStage(param openapi.NewStage, creatorName string) (*datastoreservice.KyouenPuzzle, error) {
 	// Validate stage using existing business logic
 	stage := *models.NewKyouenStage(int(param.Size), param.Stage)


### PR DESCRIPTION
認証済みユーザーがGET /v2/stagesを呼び出した場合、
各ステージに cleared フィールドを追加してクリア状況を返却する。
未認証（ゲスト）の場合は cleared フィールドは返却しない。

https://claude.ai/code/session_01PXQKriz5w1iZaRP62atLt8