### PR TITLE
feat: GET /stages の cleared を clear_date に変更

### DIFF
--- a/docs/specs/index.yaml
+++ b/docs/specs/index.yaml
@@ -557,17 +557,19 @@ components:
           format: date-time
           description: ステージ登録タイムスタンプ (UTC)
           example: "2024-01-15T10:30:00Z"
-        cleared:
-          type: boolean
-          description: ログインユーザーがこのステージをクリア済みかどうか（ログイン時のみ返却）
-          example: true
+        clear_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: ログインユーザーがこのステージをクリアした日時（ログイン時のみ返却。非nullの場合クリア済み）
+          example: "2024-01-15T10:30:00Z"
       example:
         stage_no: 12
         size: 6
         stage: "000000010000001100001100000000001000"
         creator: "noboru"
         regist_date: "2024-01-15T10:30:00Z"
-        cleared: true
+        clear_date: "2024-01-15T10:30:00Z"
     NewStage:
       type: object
       description: 新しい共円パズルステージ作成用データ

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -74,15 +74,15 @@ func (s *DatastoreService) GetStages(startStageNo int, limit int) ([]KyouenPuzzl
 	return stages, keys, nil
 }
 
-// GetClearedStageKeyIDs returns a set of Datastore key IDs for stages cleared by the given user.
-func (s *DatastoreService) GetClearedStageKeyIDs(userKey *datastore.Key) (map[int64]bool, error) {
+// GetClearedStageKeyIDs returns a map of Datastore key ID to clear date for stages cleared by the given user.
+func (s *DatastoreService) GetClearedStageKeyIDs(userKey *datastore.Key) (map[int64]time.Time, error) {
 	stageUsers, err := s.GetClearedStagesByUser(userKey)
 	if err != nil {
 		return nil, err
 	}
-	result := make(map[int64]bool, len(stageUsers))
+	result := make(map[int64]time.Time, len(stageUsers))
 	for _, su := range stageUsers {
-		result[su.StageKey.ID] = true
+		result[su.StageKey.ID] = su.ClearDate
 	}
 	return result, nil
 }

--- a/internal/generated/openapi/model_stage.go
+++ b/internal/generated/openapi/model_stage.go
@@ -36,8 +36,8 @@ type Stage struct {
 	// ステージ登録タイムスタンプ (UTC)
 	RegistDate time.Time `json:"regist_date"`
 
-	// ログインユーザーがクリア済みかどうか（ログイン時のみ返却）
-	Cleared *bool `json:"cleared,omitempty"`
+	// ログインユーザーがこのステージをクリアした日時（ログイン時のみ返却。非nullの場合クリア済み）
+	ClearDate *time.Time `json:"clear_date,omitempty"`
 }
 
 // AssertStageRequired checks if the required fields are not zero-ed

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -59,8 +59,9 @@ func (h *Handler) GetStages(c *gin.Context) {
 			RegistDate: stage.RegistDate,
 		}
 		if clearedKeyIDs != nil {
-			cleared := clearedKeyIDs[stageKeys[i].ID]
-			s.Cleared = &cleared
+			if clearDate, ok := clearedKeyIDs[stageKeys[i].ID]; ok {
+				s.ClearDate = &clearDate
+			}
 		}
 		stageList = append(stageList, s)
 	}

--- a/internal/stage/service.go
+++ b/internal/stage/service.go
@@ -41,13 +41,13 @@ func NewService(datastoreService *datastoreservice.DatastoreService, firebaseSer
 	}
 }
 
-func (s *Service) GetStages(startStageNo, limit int, authUID string) ([]datastoreservice.KyouenPuzzle, []*datastore.Key, map[int64]bool, error) {
+func (s *Service) GetStages(startStageNo, limit int, authUID string) ([]datastoreservice.KyouenPuzzle, []*datastore.Key, map[int64]time.Time, error) {
 	stages, stageKeys, err := s.datastoreService.GetStages(startStageNo, limit)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	var clearedKeyIDs map[int64]bool
+	var clearedKeyIDs map[int64]time.Time
 	if authUID != "" && !auth.IsGuestUser(authUID) {
 		_, userKey, userErr := s.datastoreService.GetUserByID(authUID)
 		if userErr == nil {


### PR DESCRIPTION
## Summary

- `Stage` レスポンスの `cleared: boolean` を `clear_date: date-time (nullable)` に変更
- `clear_date` が非 null であることがクリア済みを示す（`cleared !== null` で判定可能）
- クリア済みかどうかだけでなく、クリア日時も同時に取得できるようになった

## 変更ファイル

- `docs/specs/index.yaml` — `Stage` スキーマの `cleared` → `clear_date` に変更
- `internal/generated/openapi/model_stage.go` — `Cleared *bool` → `ClearDate *time.Time`
- `internal/datastore/datastore.go` — `GetClearedStageKeyIDs` の返り値を `map[int64]bool` → `map[int64]time.Time`
- `internal/stage/service.go` / `handler.go` — 上記に合わせて型と参照を更新

## Test plan

- [ ] `go build ./...` が成功すること
- [ ] `go test ./internal/stage/...` がパスすること
- [ ] 未ログイン時: `clear_date` フィールドが返却されないこと
- [ ] ログイン済み・未クリアステージ: `clear_date` が null または省略されること
- [ ] ログイン済み・クリア済みステージ: `clear_date` に日時が返却されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)