### PR TITLE
perf: /v2/activities の N+1 クエリを解消し応答速度を改善

### DIFF
--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -560,14 +560,42 @@ func (s *DatastoreService) GetStageByKey(stageKey *datastore.Key) (*KyouenPuzzle
 	return &stage, nil
 }
 
-// GetStagesByKeys gets multiple stages by datastore keys
+// GetStagesByKeys gets multiple stages by datastore keys.
+// ErrNoSuchEntity entries are returned as zero-value KyouenPuzzle; other errors abort.
 func (s *DatastoreService) GetStagesByKeys(keys []*datastore.Key) ([]KyouenPuzzle, error) {
 	stages := make([]KyouenPuzzle, len(keys))
 	err := s.client.GetMulti(s.ctx, keys, stages)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get stages by keys: %w", err)
+	if err == nil {
+		return stages, nil
 	}
-	return stages, nil
+	if merr, ok := err.(datastore.MultiError); ok {
+		for _, e := range merr {
+			if e != nil && e != datastore.ErrNoSuchEntity {
+				return nil, fmt.Errorf("failed to get stages by keys: %w", err)
+			}
+		}
+		return stages, nil
+	}
+	return nil, fmt.Errorf("failed to get stages by keys: %w", err)
+}
+
+// GetUsersByKeys gets multiple users by datastore keys.
+// ErrNoSuchEntity entries are returned as zero-value User; other errors abort.
+func (s *DatastoreService) GetUsersByKeys(keys []*datastore.Key) ([]User, error) {
+	users := make([]User, len(keys))
+	err := s.client.GetMulti(s.ctx, keys, users)
+	if err == nil {
+		return users, nil
+	}
+	if merr, ok := err.(datastore.MultiError); ok {
+		for _, e := range merr {
+			if e != nil && e != datastore.ErrNoSuchEntity {
+				return nil, fmt.Errorf("failed to get users by keys: %w", err)
+			}
+		}
+		return users, nil
+	}
+	return nil, fmt.Errorf("failed to get users by keys: %w", err)
 }
 
 // createRegistModel creates a RegistModel record for a given stage

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -304,64 +304,39 @@ func (h *Handler) GetRecentStages(c *gin.Context) {
 	c.JSON(http.StatusOK, stageList)
 }
 
-type ActivityStage struct {
-	StageNo int64     `json:"stageNo"`
-	ClearDate time.Time `json:"clearDate"`
+type ActivityStageResponse struct {
+	StageNo   int64     `json:"stage_no"`
+	ClearDate time.Time `json:"clear_date"`
 }
 
-type ActivityUser struct {
-	ScreenName    string          `json:"screenName"`
-	Image         string          `json:"image"`
-	ClearedStages []ActivityStage `json:"clearedStages"`
+type ActivityUserResponse struct {
+	ScreenName    string                `json:"screen_name"`
+	Image         string                `json:"image"`
+	ClearedStages []ActivityStageResponse `json:"cleared_stages"`
 }
 
 func (h *Handler) GetActivities(c *gin.Context) {
-	stageUsers, err := h.datastoreService.GetRecentActivities(50)
+	activities, err := h.stageService.GetActivities(50)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	// Group activities by user
-	userActivities := make(map[string]*ActivityUser)
-	for _, stageUser := range stageUsers {
-		// Get user information
-		user, err := h.datastoreService.GetUserByKey(stageUser.UserKey)
-		if err != nil {
-			continue // Skip if user not found
+	resp := make([]ActivityUserResponse, 0, len(activities))
+	for _, a := range activities {
+		cs := make([]ActivityStageResponse, len(a.ClearedStages))
+		for i, s := range a.ClearedStages {
+			cs[i] = ActivityStageResponse{StageNo: s.StageNo, ClearDate: s.ClearDate}
 		}
-
-		// Get stage information
-		stage, err := h.datastoreService.GetStageByKey(stageUser.StageKey)
-		if err != nil {
-			continue // Skip if stage not found
-		}
-
-		// Create or update user activity
-		if _, exists := userActivities[user.UserID]; !exists {
-			userActivities[user.UserID] = &ActivityUser{
-				ScreenName:    user.ScreenName,
-				Image:         user.Image,
-				ClearedStages: []ActivityStage{},
-			}
-		}
-
-		userActivities[user.UserID].ClearedStages = append(
-			userActivities[user.UserID].ClearedStages,
-			ActivityStage{
-				StageNo:   stage.StageNo,
-				ClearDate: stageUser.ClearDate,
-			},
-		)
+		resp = append(resp, ActivityUserResponse{
+			ScreenName:    a.ScreenName,
+			Image:         a.Image,
+			ClearedStages: cs,
+		})
 	}
 
-	// Convert to response format
-	var activities []ActivityUser
-	for _, activity := range userActivities {
-		activities = append(activities, *activity)
-	}
-
-	c.JSON(http.StatusOK, activities)
+	c.Header("Cache-Control", "public, max-age=60")
+	c.JSON(http.StatusOK, resp)
 }
 
 // Helper function for validation

--- a/internal/stage/handler_test.go
+++ b/internal/stage/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"kyouen-server/internal/auth"
@@ -14,12 +15,14 @@ import (
 // StageServiceInterface defines the interface for stage service
 type StageServiceInterface interface {
 	DeleteAccount(userUID string) error
+	GetActivities(limit int) ([]ActivityUser, error)
 }
 
 // MockStageService is a simple mock implementation of StageServiceInterface
 type MockStageService struct {
-	deleteAccountFunc func(userUID string) error
-	deleteAccountCalls []string
+	deleteAccountFunc    func(userUID string) error
+	deleteAccountCalls  []string
+	getActivitiesFunc   func(limit int) ([]ActivityUser, error)
 }
 
 func (m *MockStageService) DeleteAccount(userUID string) error {
@@ -43,6 +46,16 @@ func (m *MockStageService) WasDeleteAccountCalled(userUID string) bool {
 	return false
 }
 
+func (m *MockStageService) GetActivities(limit int) ([]ActivityUser, error) {
+	if m.getActivitiesFunc != nil {
+		return m.getActivitiesFunc(limit)
+	}
+	return []ActivityUser{}, nil
+}
+
+func (m *MockStageService) SetGetActivitiesFunc(f func(limit int) ([]ActivityUser, error)) {
+	m.getActivitiesFunc = f
+}
 
 // TestHandler is a test version of Handler that accepts interface
 type TestHandler struct {
@@ -66,6 +79,30 @@ func (h *TestHandler) DeleteAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Account deleted successfully",
 	})
+}
+
+func (h *TestHandler) GetActivities(c *gin.Context) {
+	activities, err := h.stageService.GetActivities(50)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	resp := make([]ActivityUserResponse, 0, len(activities))
+	for _, a := range activities {
+		cs := make([]ActivityStageResponse, len(a.ClearedStages))
+		for i, s := range a.ClearedStages {
+			cs[i] = ActivityStageResponse{StageNo: s.StageNo, ClearDate: s.ClearDate}
+		}
+		resp = append(resp, ActivityUserResponse{
+			ScreenName:    a.ScreenName,
+			Image:         a.Image,
+			ClearedStages: cs,
+		})
+	}
+
+	c.Header("Cache-Control", "public, max-age=60")
+	c.JSON(http.StatusOK, resp)
 }
 
 func TestDeleteAccount_Success(t *testing.T) {
@@ -107,6 +144,97 @@ func TestDeleteAccount_Success(t *testing.T) {
 	// Assert mock was called
 	if !mockService.WasDeleteAccountCalled("test-uid") {
 		t.Errorf("Expected DeleteAccount to be called with 'test-uid'")
+	}
+}
+
+func TestGetActivities_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clearDate := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	mockService := &MockStageService{}
+	mockService.SetGetActivitiesFunc(func(limit int) ([]ActivityUser, error) {
+		return []ActivityUser{
+			{
+				UserID:     "user1",
+				ScreenName: "alice",
+				Image:      "https://example.com/alice.jpg",
+				ClearedStages: []ActivityStage{
+					{StageNo: 42, ClearDate: clearDate},
+				},
+			},
+			{
+				UserID:     "user2",
+				ScreenName: "bob",
+				Image:      "https://example.com/bob.jpg",
+				ClearedStages: []ActivityStage{
+					{StageNo: 10, ClearDate: clearDate},
+				},
+			},
+		}, nil
+	})
+
+	handler := &TestHandler{stageService: mockService}
+	router := gin.New()
+	router.GET("/v2/activities", handler.GetActivities)
+
+	req, _ := http.NewRequest("GET", "/v2/activities", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+	if resp.Header().Get("Cache-Control") != "public, max-age=60" {
+		t.Errorf("Expected Cache-Control header, got: %s", resp.Header().Get("Cache-Control"))
+	}
+
+	body := resp.Body.String()
+	for _, want := range []string{"screen_name", "cleared_stages", "stage_no", "clear_date", "alice", "bob"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Expected response to contain %q, got: %s", want, body)
+		}
+	}
+}
+
+func TestGetActivities_ServiceError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockService := &MockStageService{}
+	mockService.SetGetActivitiesFunc(func(limit int) ([]ActivityUser, error) {
+		return nil, errors.New("datastore error")
+	})
+
+	handler := &TestHandler{stageService: mockService}
+	router := gin.New()
+	router.GET("/v2/activities", handler.GetActivities)
+
+	req, _ := http.NewRequest("GET", "/v2/activities", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, resp.Code)
+	}
+}
+
+func TestGetActivities_Empty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockService := &MockStageService{}
+
+	handler := &TestHandler{stageService: mockService}
+	router := gin.New()
+	router.GET("/v2/activities", handler.GetActivities)
+
+	req, _ := http.NewRequest("GET", "/v2/activities", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+	if body := resp.Body.String(); body != "[]" {
+		t.Errorf("Expected empty array [], got: %s", body)
 	}
 }
 

--- a/internal/stage/service.go
+++ b/internal/stage/service.go
@@ -220,6 +220,91 @@ func (s *Service) hasRegisteredStageAll(stage models.KyouenStage) (bool, error) 
 	return false, nil
 }
 
+type ActivityStage struct {
+	StageNo   int64
+	ClearDate time.Time
+}
+
+type ActivityUser struct {
+	UserID        string
+	ScreenName    string
+	Image         string
+	ClearedStages []ActivityStage
+}
+
+func (s *Service) GetActivities(limit int) ([]ActivityUser, error) {
+	stageUsers, err := s.datastoreService.GetRecentActivities(limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(stageUsers) == 0 {
+		return []ActivityUser{}, nil
+	}
+
+	userKeys := make([]*datastore.Key, len(stageUsers))
+	stageKeys := make([]*datastore.Key, len(stageUsers))
+	for i, su := range stageUsers {
+		userKeys[i] = su.UserKey
+		stageKeys[i] = su.StageKey
+	}
+	uUserKeys, userIdx := uniqueKeys(userKeys)
+	uStageKeys, stageIdx := uniqueKeys(stageKeys)
+
+	users, err := s.datastoreService.GetUsersByKeys(uUserKeys)
+	if err != nil {
+		return nil, err
+	}
+	stages, err := s.datastoreService.GetStagesByKeys(uStageKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	activityMap := make(map[string]*ActivityUser)
+	var order []string
+	for _, su := range stageUsers {
+		u := users[userIdx[su.UserKey.String()]]
+		if u.UserID == "" {
+			continue
+		}
+		st := stages[stageIdx[su.StageKey.String()]]
+		if st.StageNo == 0 {
+			continue
+		}
+		if _, ok := activityMap[u.UserID]; !ok {
+			activityMap[u.UserID] = &ActivityUser{
+				UserID:     u.UserID,
+				ScreenName: u.ScreenName,
+				Image:      u.Image,
+			}
+			order = append(order, u.UserID)
+		}
+		activityMap[u.UserID].ClearedStages = append(
+			activityMap[u.UserID].ClearedStages,
+			ActivityStage{StageNo: st.StageNo, ClearDate: su.ClearDate},
+		)
+	}
+
+	result := make([]ActivityUser, 0, len(order))
+	for _, id := range order {
+		result = append(result, *activityMap[id])
+	}
+	return result, nil
+}
+
+func uniqueKeys(keys []*datastore.Key) ([]*datastore.Key, map[string]int) {
+	idx := make(map[string]int, len(keys))
+	unique := make([]*datastore.Key, 0, len(keys))
+	for _, k := range keys {
+		s := k.String()
+		if _, ok := idx[s]; ok {
+			continue
+		}
+		idx[s] = len(unique)
+		unique = append(unique, k)
+	}
+	return unique, idx
+}
+
 // DeleteAccount deletes a user account and all associated data
 func (s *Service) DeleteAccount(userUID string) error {
 	// TODO: Add audit log for account deletion request (required for compliance)

--- a/internal/stage/service_test.go
+++ b/internal/stage/service_test.go
@@ -1,0 +1,59 @@
+package stage
+
+import (
+	"testing"
+
+	"cloud.google.com/go/datastore"
+)
+
+func makeKey(kind string, id int64) *datastore.Key {
+	return &datastore.Key{Kind: kind, ID: id}
+}
+
+func TestUniqueKeys_Deduplication(t *testing.T) {
+	k1 := makeKey("User", 1)
+	k2 := makeKey("User", 2)
+	keys := []*datastore.Key{k1, k2, k1, k2, k1}
+
+	unique, idx := uniqueKeys(keys)
+
+	if len(unique) != 2 {
+		t.Errorf("Expected 2 unique keys, got %d", len(unique))
+	}
+	if len(idx) != 2 {
+		t.Errorf("Expected idx length 2, got %d", len(idx))
+	}
+	if idx[k1.String()] != 0 {
+		t.Errorf("Expected k1 at index 0, got %d", idx[k1.String()])
+	}
+	if idx[k2.String()] != 1 {
+		t.Errorf("Expected k2 at index 1, got %d", idx[k2.String()])
+	}
+}
+
+func TestUniqueKeys_Empty(t *testing.T) {
+	unique, idx := uniqueKeys([]*datastore.Key{})
+
+	if len(unique) != 0 {
+		t.Errorf("Expected 0 unique keys, got %d", len(unique))
+	}
+	if len(idx) != 0 {
+		t.Errorf("Expected empty idx, got %d", len(idx))
+	}
+}
+
+func TestUniqueKeys_OrderPreserved(t *testing.T) {
+	k1 := makeKey("Stage", 10)
+	k2 := makeKey("Stage", 20)
+	k3 := makeKey("Stage", 30)
+	keys := []*datastore.Key{k3, k1, k2, k3, k1}
+
+	unique, _ := uniqueKeys(keys)
+
+	if len(unique) != 3 {
+		t.Errorf("Expected 3 unique keys, got %d", len(unique))
+	}
+	if unique[0].ID != 30 || unique[1].ID != 10 || unique[2].ID != 20 {
+		t.Errorf("Expected order [k3, k1, k2], got [%d, %d, %d]", unique[0].ID, unique[1].ID, unique[2].ID)
+	}
+}


### PR DESCRIPTION
## 概要

`/v2/activities` エンドポイントが本番で数十秒かかる問題を解消する。

## 問題の根本原因

`StageUser` 50 件に対してループ内で `GetUserByKey` / `GetStageByKey` を同期的に発行しており、最大 100 回のシリアル RPC が発生していた（1 往復あたり 10〜50ms × 100 回）。

## 変更内容

- **N+1 解消**: `GetMulti` による一括取得（3 RPC）に変更し、重複キーは `uniqueKeys` で除去
- **Service 層移管**: ロジックを `stage.Service.GetActivities` に集約（他エンドポイントと一貫性確保）
- **snake_case 統一**: JSON キーを OpenAPI 仕様 (`screen_name`, `cleared_stages`, `stage_no`, `clear_date`) に合わせ修正
- **キャッシュ**: `Cache-Control: public, max-age=60` を付与（公開エンドポイントのため CDN / ブラウザで効果あり）
- **部分エラー許容**: `GetStagesByKeys` / `GetUsersByKeys` で `ErrNoSuchEntity` のみスキップし削除済みエンティティを安全に無視

## 期待効果

| 項目 | 変更前 | 変更後 |
|---|---|---|
| Datastore RPC 回数 | 最大 101 回（シリアル） | 3 回 |
| 想定レスポンス時間 | 10〜数十秒 | 1 秒未満 |

## 注意事項

JSON キーを `camelCase` から `snake_case` に変更したため、クライアント側に破壊的変更が生じる可能性があります。`/v2/activities` を参照している Android クライアント（`kyouen-android`）の実装を確認してから本番にマージしてください。

## テスト計画

- [x] `go test -v ./internal/stage/...` — ハンドラーテスト 3 件、`uniqueKeys` テスト 3 件すべて PASS
- [x] `go build ./...` — ビルドエラーなし
- [ ] ローカル emulator 環境で `curl -i http://localhost:8080/v2/activities` の動作確認（レスポンスヘッダ・キー名確認）
- [ ] 本番デプロイ後に Cloud Run ログでレスポンスタイム改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)