### PR TITLE
fix: Firebase UID 再発行に伴うユーザーデータ補正 CLI を追加

### DIFF
--- a/cmd/migrate_user/main.go
+++ b/cmd/migrate_user/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"kyouen-server/internal/datastore"
+
+	gcdatastore "cloud.google.com/go/datastore"
+)
+
+func main() {
+	oldUID := flag.String("old-uid", "", "補正前の Firebase UID（必須）")
+	newUID := flag.String("new-uid", "", "補正後の Firebase UID（必須）")
+	dryRun := flag.Bool("dry-run", false, "true にすると Datastore への書き込みを行わず検証結果のみ表示")
+	flag.Parse()
+
+	if *oldUID == "" || *newUID == "" {
+		fmt.Fprintln(os.Stderr, "使用方法: migrate_user -old-uid=<旧UID> -new-uid=<新UID> [-dry-run]")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if projectID == "" {
+		projectID = "my-android-server"
+		log.Printf("GOOGLE_CLOUD_PROJECT が未設定のためデフォルトを使用: %s", projectID)
+	}
+
+	svc, err := datastore.NewDatastoreService(projectID)
+	if err != nil {
+		log.Fatalf("Datastore 接続に失敗: %v", err)
+	}
+	defer svc.Close()
+
+	fmt.Printf("接続先プロジェクト: %s\n", projectID)
+	fmt.Printf("旧 UID: %s\n", *oldUID)
+	fmt.Printf("新 UID: %s\n", *newUID)
+	if *dryRun {
+		fmt.Println("モード: dry-run（書き込みは行いません）")
+	} else {
+		fmt.Println("モード: 実行（Datastore に書き込みます）")
+	}
+	fmt.Println("---")
+
+	// 旧 User を取得
+	oldUser, _, err := svc.GetUserByID(*oldUID)
+	if err != nil {
+		log.Fatalf("旧ユーザーが見つかりません（%s）: %v", *oldUID, err)
+	}
+	fmt.Printf("旧ユーザー: screenName=%s, twitterUid=%s, clearStageCount=%d\n",
+		oldUser.ScreenName, oldUser.TwitterUID, oldUser.ClearStageCount)
+
+	// 新 User を取得
+	newUser, _, err := svc.GetUserByID(*newUID)
+	if err != nil {
+		log.Fatalf("新ユーザーが見つかりません（%s）: %v\n補正前に新 UID でログインしてください。", *newUID, err)
+	}
+	fmt.Printf("新ユーザー: screenName=%s, twitterUid=%s, clearStageCount=%d\n",
+		newUser.ScreenName, newUser.TwitterUID, newUser.ClearStageCount)
+
+	// twitterUid の一致チェック（誤補正防止）
+	if oldUser.TwitterUID != newUser.TwitterUID {
+		log.Fatalf(
+			"旧ユーザーと新ユーザーの twitterUid が一致しません（旧: %s / 新: %s）。同一人物であることを確認してください。",
+			oldUser.TwitterUID, newUser.TwitterUID,
+		)
+	}
+	fmt.Printf("twitterUid 一致確認: OK (%s)\n", oldUser.TwitterUID)
+
+	// StageUser 件数確認
+	oldKey := gcdatastore.NameKey("User", "KEY"+*oldUID, nil)
+	newKey := gcdatastore.NameKey("User", "KEY"+*newUID, nil)
+
+	oldStageUserCount, err := svc.CountStageUsersByUserKey(oldKey)
+	if err != nil {
+		log.Fatalf("旧ユーザーの StageUser 件数取得に失敗: %v", err)
+	}
+	fmt.Printf("旧ユーザー StageUser 件数: %d 件\n", oldStageUserCount)
+
+	newStageUserCount, err := svc.CountStageUsersByUserKey(newKey)
+	if err != nil {
+		log.Fatalf("新ユーザーの StageUser 件数取得に失敗: %v", err)
+	}
+	fmt.Printf("新ユーザー StageUser 件数: %d 件\n", newStageUserCount)
+
+	if newStageUserCount > 0 {
+		log.Fatalf(
+			"新ユーザー側に既に StageUser が %d 件存在します。データ損失を防ぐため中断しました。",
+			newStageUserCount,
+		)
+	}
+
+	fmt.Println("---")
+	fmt.Printf("補正内容:\n")
+	fmt.Printf("  旧 User エンティティ (KEY%s) を削除\n", *oldUID)
+	fmt.Printf("  新 User エンティティ (KEY%s) の clearStageCount を %d に更新\n", *newUID, oldUser.ClearStageCount)
+	fmt.Printf("  StageUser %d 件の UserKey を新 UID に差し替え\n", oldStageUserCount)
+	fmt.Printf("  UserMigration レコードを 1 件追加\n")
+
+	if *dryRun {
+		fmt.Println("---")
+		fmt.Println("dry-run 完了。上記の変更は行われていません。")
+		return
+	}
+
+	fmt.Println("---")
+	fmt.Println("補正を実行します...")
+
+	migratedUser, err := svc.MigrateFirebaseUID(*oldUID, *newUID)
+	if err != nil {
+		log.Fatalf("補正に失敗しました: %v", err)
+	}
+
+	fmt.Printf("補正完了: screenName=%s, clearStageCount=%d\n",
+		migratedUser.ScreenName, migratedUser.ClearStageCount)
+
+	// 事後確認
+	afterOldCount, _ := svc.CountStageUsersByUserKey(oldKey)
+	afterNewCount, _ := svc.CountStageUsersByUserKey(newKey)
+	fmt.Println("---")
+	fmt.Println("事後確認:")
+	fmt.Printf("  旧ユーザー StageUser 件数: %d 件（0 になっているはずです）\n", afterOldCount)
+	fmt.Printf("  新ユーザー StageUser 件数: %d 件（補正前の旧ユーザー件数と一致するはずです）\n", afterNewCount)
+
+	if afterOldCount != 0 {
+		fmt.Println("  警告: 旧ユーザー側に StageUser が残っています。再実行が必要な可能性があります。")
+	}
+	if afterNewCount != oldStageUserCount {
+		fmt.Printf("  警告: 新ユーザー StageUser 件数 (%d) が期待値 (%d) と異なります。\n",
+			afterNewCount, oldStageUserCount)
+	}
+}

--- a/docs/adr/003-firebase-uid-rekey-migration.md
+++ b/docs/adr/003-firebase-uid-rekey-migration.md
@@ -1,0 +1,130 @@
+# ADR 003: Firebase UID 再発行に伴うユーザーデータ補正方式
+
+## ステータス
+
+採用済み (2026-04-24)
+
+## コンテキスト
+
+本番 Firebase Authentication 上のユーザーアカウントをオペレーションミスで削除してしまい、同じ Twitter アカウントで再作成したところ Firebase UID が変わってしまった。
+
+Datastore 上の `User` エンティティはキー名が `"KEY" + Firebase UID` となっており、`StageUser` エンティティもこの User キーを `user` プロパティとして参照している。UID が変わると以下のデータが失われる。
+
+| エンティティ / フィールド | 問題 |
+|---|---|
+| `User` エンティティキー | 旧 UID のキーが残り、新 UID でのログイン時に新規ユーザーとして作成される |
+| `User.clearStageCount` | 旧ユーザーのクリア数が引き継がれない |
+| `StageUser.user` | 旧 User キーを参照したまま、新 UID 側では参照されない |
+
+また、アカウント再作成後にアプリからログインを行ったため、新 UID の `User` エンティティが `clearStageCount=0` の状態で自動生成されていた。
+
+Firebase Auth の「UID の変更」という操作は存在しないため、Datastore 側のデータを手動で補正する必要がある。
+
+## 決定事項
+
+**専用の補正 CLI (`cmd/migrate_user`) を 1 回限りのツールとして新設し、手動で実行する**ことにした。
+
+既存の ADR 002 で実装済みの `MigrateLegacyUser`（Python 時代の Twitter UID キー → Firebase UID キーの移行）と同一のデータ処理パターン（トランザクション内での User 差し替え + トランザクション外での StageUser 再ポイント）を流用する。
+
+### 補正の処理内容
+
+事前検証:
+- 旧 UID / 新 UID の `User` エンティティがどちらも存在することを確認
+- `twitterUid` フィールドの一致で同一人物であることを確認（誤補正防止）
+- 新 UID 側の `StageUser` が 0 件であることを確認（ありえないが念のため）
+
+トランザクション内（原子性を保証）:
+1. 旧 User エンティティを読み取り、`clearStageCount` を取得
+2. 新 User エンティティを読み取り、`clearStageCount` を旧ユーザー値で上書きして `Put`（`screenName` / `image` / `twitterUid` は新 User 側の値を維持）
+3. `UserMigration` レコードを作成（監査ログ。`OldKey` に旧UID、`NewKey` に新UID、`FirebaseUID` に新UID を記録）
+4. 旧 User エンティティを削除
+
+トランザクション外（Datastore の 25 エンティティグループ制限のため）:
+5. 旧 User キーを参照する `StageUser` レコードを新 User キーに更新
+
+### dry-run モード
+
+`-dry-run` フラグで書き込みなしの事前確認が可能。本実行前に必ず dry-run を実施する。
+
+## 検討した代替案
+
+### 案 A: 通常ログインフローでの自動補正
+
+`CreateOrUpdateUserFromFirebase` にロジックを追加し、「旧 UID のユーザーが存在し twitterUid が一致する場合は自動マイグレーション」を行う。
+
+**却下理由**: 通常ログインフローへの影響範囲が大きく、1 回限りの補正のためにランタイムに常時ロジックを残すのは好ましくない。また、今回は新 UID 側にも既に User エンティティが存在するため、既存の `CreateOrUpdateUserFromFirebase` の分岐（`ErrNoSuchEntity` のみ）には乗れない。
+
+### 案 B: gcloud / Datastore コンソールで手動操作
+
+コンソールからエンティティのキーを書き換える。
+
+**却下理由**: Datastore ではキー名の変更ができないため、削除→再作成が必要になる。`StageUser` の書き換えも手作業では件数が多く、ミスのリスクが高い。
+
+### 案 C: 採用案（専用 CLI）
+
+**採用理由**:
+- 既存の `MigrateLegacyUser` / `migrateStageUserRecords` の実績ある実装を流用でき、安全
+- dry-run で実行前に内容を確認できる
+- `twitterUid` 一致チェックにより誤補正を防止できる
+- 事後に件数を照合して補正の完全性を確認できる
+- 1 回限り利用後は削除 or 残置を選択できる
+
+## 実行手順
+
+### 前提
+
+- ローカル PC に gcloud CLI がインストールされていること
+- `go run` でビルド可能な環境であること
+- 旧 Firebase UID と新 Firebase UID を把握していること
+
+### 手順
+
+```bash
+# 1. Application Default Credentials で本番 Datastore に接続できるよう認証
+gcloud auth application-default login
+
+# 2. dry-run で補正内容を確認（書き込みは行われない）
+GOOGLE_CLOUD_PROJECT=my-android-server \
+  go run cmd/migrate_user/main.go \
+  -old-uid=<旧FirebaseUID> \
+  -new-uid=<新FirebaseUID> \
+  -dry-run
+
+# dry-run の出力例:
+# 旧ユーザー: screenName=noboru, twitterUid=12345678, clearStageCount=42
+# 新ユーザー: screenName=noboru, twitterUid=12345678, clearStageCount=0
+# twitterUid 一致確認: OK (12345678)
+# 旧ユーザー StageUser 件数: 42 件
+# 新ユーザー StageUser 件数: 0 件
+# 補正内容:
+#   旧 User エンティティ (KEY<旧UID>) を削除
+#   新 User エンティティ (KEY<新UID>) の clearStageCount を 42 に更新
+#   StageUser 42 件の UserKey を新 UID に差し替え
+#   UserMigration レコードを 1 件追加
+# dry-run 完了。上記の変更は行われていません。
+
+# 3. 内容を確認し、問題なければ本実行
+GOOGLE_CLOUD_PROJECT=my-android-server \
+  go run cmd/migrate_user/main.go \
+  -old-uid=<旧FirebaseUID> \
+  -new-uid=<新FirebaseUID>
+```
+
+### 補正後の確認
+
+1. `UserMigration` エンティティに本日付の新規レコードが 1 件追加されていること
+2. Datastore コンソールで `KEY<旧UID>` の User が存在しないこと
+3. `KEY<新UID>` の User の `clearStageCount` が補正前の値になっていること
+4. アプリから新 UID でログインし `GET /v2/stages` でクリア済みステージが正しく返ること
+5. CLI の事後確認出力で旧ユーザー StageUser 件数が 0、新ユーザー StageUser 件数が期待値と一致していること
+
+## 影響
+
+- `cmd/migrate_user/main.go`: 補正 CLI の新設
+- `internal/datastore/datastore.go`: `MigrateFirebaseUID`、`CountStageUsersByUserKey` の追加
+
+## トレードオフ・注意事項
+
+- ADR 002 と同様に、`StageUser` レコードの更新はトランザクション外のため、処理中断時に一部のレコードが旧キーを参照したままになる可能性がある。CLI を再実行することで残余レコードを補正できる（残存した旧 User エンティティが存在しないため再実行は旧キーの Get が失敗してトランザクションがエラーになるが、StageUser 再ポイントは `migrateStageUserRecords` を直接呼ぶ手順で個別対応が可能）。
+- `UserMigration.TwitterUID` フィールドには旧 Firebase UID ではなく Twitter UID が入る（既存スキーマの制約）。`OldKey` / `NewKey` / `MigratedAt` で補正の追跡は十分可能。
+- 新 UID 側に `StageUser` が存在する場合は安全のため CLI が中断する。その場合は StageUser のマージ戦略を別途検討すること。

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -598,6 +598,71 @@ func (s *DatastoreService) GetUsersByKeys(keys []*datastore.Key) ([]User, error)
 	return nil, fmt.Errorf("failed to get users by keys: %w", err)
 }
 
+// MigrateFirebaseUID migrates a user from an old Firebase UID to a new one.
+// This handles the case where a Firebase Auth account was deleted and re-created,
+// resulting in a new UID. The new-UID User entity must already exist in Datastore.
+func (s *DatastoreService) MigrateFirebaseUID(oldUID, newUID string) (*User, error) {
+	oldKey := datastore.NameKey("User", "KEY"+oldUID, nil)
+	newKey := datastore.NameKey("User", "KEY"+newUID, nil)
+
+	var migratedUser User
+
+	_, err := s.client.RunInTransaction(s.ctx, func(tx *datastore.Transaction) error {
+		var oldUser User
+		if err := tx.Get(oldKey, &oldUser); err != nil {
+			return fmt.Errorf("旧ユーザーの取得に失敗: %w", err)
+		}
+
+		var newUser User
+		if err := tx.Get(newKey, &newUser); err != nil {
+			return fmt.Errorf("新ユーザーの取得に失敗: %w", err)
+		}
+
+		// clearStageCount を旧ユーザーから引き継ぐ（screenName/image/twitterUid は新側を維持）
+		newUser.ClearStageCount = oldUser.ClearStageCount
+		migratedUser = newUser
+		if _, err := tx.Put(newKey, &newUser); err != nil {
+			return fmt.Errorf("新ユーザーの更新に失敗: %w", err)
+		}
+
+		migration := UserMigration{
+			OldKey:      "KEY" + oldUID,
+			NewKey:      "KEY" + newUID,
+			TwitterUID:  oldUser.TwitterUID,
+			FirebaseUID: newUID,
+			MigratedAt:  time.Now(),
+		}
+		migrationKey := datastore.IncompleteKey("UserMigration", nil)
+		if _, err := tx.Put(migrationKey, &migration); err != nil {
+			return fmt.Errorf("UserMigration レコードの保存に失敗: %w", err)
+		}
+
+		if err := tx.Delete(oldKey); err != nil {
+			return fmt.Errorf("旧ユーザーの削除に失敗: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Firebase UID 補正に失敗: %w", err)
+	}
+
+	// StageUser の UserKey を新キーに差し替える（トランザクション外: 25エンティティグループ制限のため）
+	s.migrateStageUserRecords(oldKey, newKey)
+
+	return &migratedUser, nil
+}
+
+// CountStageUsersByUserKey counts StageUser records that reference the given user key.
+func (s *DatastoreService) CountStageUsersByUserKey(userKey *datastore.Key) (int, error) {
+	query := datastore.NewQuery("StageUser").FilterField("user", "=", userKey).KeysOnly()
+	keys, err := s.client.GetAll(s.ctx, query, &[]StageUser{})
+	if err != nil {
+		return 0, fmt.Errorf("StageUser 件数の取得に失敗: %w", err)
+	}
+	return len(keys), nil
+}
+
 // createRegistModel creates a RegistModel record for a given stage
 func (s *DatastoreService) createRegistModel(stageKey *datastore.Key) error {
 	registModel := RegistModel{


### PR DESCRIPTION
## Summary

- Firebase Auth アカウントを誤削除・再作成して UID が変わった場合に、Datastore 上のユーザーデータを新 UID に補正するための 1 回限りの CLI (`cmd/migrate_user`) を追加
- `internal/datastore` に `MigrateFirebaseUID` / `CountStageUsersByUserKey` メソッドを追加（既存の `MigrateLegacyUser` と同パターンを流用）
- ADR 003 として補正方式・実行手順をドキュメント化

## 変更ファイル

- `cmd/migrate_user/main.go` — 補正 CLI。`-old-uid`, `-new-uid`, `-dry-run` フラグを受け付け、事前検証→dry-run確認→本実行→事後確認の流れで動作
- `internal/datastore/datastore.go` — `MigrateFirebaseUID`（Tx内でUser差し替え+UserMigration監査+旧User削除、Tx外でStageUser再ポイント）、`CountStageUsersByUserKey`（件数確認用）を追加
- `docs/adr/003-firebase-uid-rekey-migration.md` — 採用経緯・代替案・実行手順・注意事項を記載

## Test plan

- [ ] dry-run で補正内容が正しく出力されることを確認
- [ ] 本番実行前に `GOOGLE_CLOUD_PROJECT=my-android-server go run cmd/migrate_user/main.go -old-uid=<旧UID> -new-uid=<新UID> -dry-run` を実行して内容を確認
- [ ] 本番実行後、Datastore コンソールで旧 UID の User が消えていること・新 UID の clearStageCount が正しいことを確認
- [ ] アプリから新 UID でログインし `GET /v2/stages` でクリア済みステージが正しく返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)