### PR TITLE
feat: POST /v2/stages を認証不要にし、リクエストボディの creator を使用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ api-project-1046368181881-firebase-adminsdk-df1u6-039d87ad7a.json
 *.dll
 *.so
 *.dylib
-server
+/server
 
 # Go build cache
 .cache/

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,8 +112,7 @@ func setupRouter(app *App) *gin.Engine {
 		stages := v2.Group("/stages")
 		{
 			stages.GET("", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.GetStages)
-			// Protected endpoints requiring authentication
-			stages.POST("", auth.FirebaseAuth(app.FirebaseService), stageHandler.CreateStage)
+			stages.POST("", stageHandler.CreateStage)
 			stages.POST("/sync", auth.FirebaseAuth(app.FirebaseService), stageHandler.SyncStages)
 			// This endpoint accepts both authenticated and guest users
 			stages.PUT("/:stageNo/clear", auth.OptionalFirebaseAuth(app.FirebaseService), stageHandler.ClearStage)

--- a/internal/stage/handler.go
+++ b/internal/stage/handler.go
@@ -70,20 +70,13 @@ func (h *Handler) GetStages(c *gin.Context) {
 }
 
 func (h *Handler) CreateStage(c *gin.Context) {
-	// Get authenticated user from context
-	authUser, exists := auth.GetAuthenticatedUser(c)
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
-		return
-	}
-
 	var param openapi.NewStage
 	if err := c.ShouldBindJSON(&param); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	savedStage, err := h.stageService.CreateStage(param, authUser.Name)
+	savedStage, err := h.stageService.CreateStage(param, param.Creator)
 	if err != nil {
 		switch err {
 		case ErrInsufficientStones:


### PR DESCRIPTION
## Summary

- `POST /v2/stages` から Firebase 認証ミドルウェア (`FirebaseAuth`) を削除
- `CreateStage` ハンドラーの認証チェックを削除し、リクエストボディの `creator` フィールドをそのまま保存に使用

## Test plan

- [ ] 認証なしで `POST /v2/stages` にリクエストを送信し、`creator` に指定した値でステージが作成されること
- [ ] `size`・`stage`・`creator` のいずれかが不正な場合は 400 が返ること
- [ ] 重複ステージの場合は 409 が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)